### PR TITLE
Do not require sentence to be moved into SentenceWithPieces

### DIFF
--- a/syntaxdot-cli/src/subcommands/filter_len.rs
+++ b/syntaxdot-cli/src/subcommands/filter_len.rs
@@ -82,9 +82,9 @@ impl SyntaxDotApp for FilterLenApp {
 
             let sentence_with_pieces = tokenizer.tokenize(sentence);
 
-            if sentence_with_pieces.pieces.len() <= self.max_len {
+            if sentence_with_pieces.pieces().len() <= self.max_len {
                 treebank_writer
-                    .write_sentence(&sentence_with_pieces.sentence)
+                    .write_sentence(sentence_with_pieces.sentence())
                     .context("Cannot write sentence")?;
             }
         }

--- a/syntaxdot/src/input/albert.rs
+++ b/syntaxdot/src/input/albert.rs
@@ -1,7 +1,8 @@
 use conllu::graph::{Node, Sentence};
 use sentencepiece::SentencePieceProcessor;
 
-use crate::input::{SentenceWithPieces, Tokenize};
+use crate::input::pieces::PiecesWithOffsets;
+use crate::input::Tokenize;
 
 /// Tokenizer for ALBERT models.
 ///
@@ -27,7 +28,7 @@ impl From<SentencePieceProcessor> for AlbertTokenizer {
 }
 
 impl Tokenize for AlbertTokenizer {
-    fn tokenize(&self, sentence: Sentence) -> SentenceWithPieces {
+    fn tokenize_(&self, sentence: &Sentence) -> PiecesWithOffsets {
         // An average of three pieces per token ought to be enough for
         // everyone ;).
         let mut pieces = Vec::with_capacity((sentence.len() + 1) * 3);
@@ -69,9 +70,8 @@ impl Tokenize for AlbertTokenizer {
                 .expect("ALBERT model does not have a [SEP] token") as i64,
         );
 
-        SentenceWithPieces {
+        PiecesWithOffsets {
             pieces: pieces.into(),
-            sentence,
             token_offsets,
         }
     }

--- a/syntaxdot/src/input/bert.rs
+++ b/syntaxdot/src/input/bert.rs
@@ -1,7 +1,8 @@
 use conllu::graph::{Node, Sentence};
 use wordpieces::WordPieces;
 
-use crate::input::{SentenceWithPieces, Tokenize};
+use crate::input::pieces::PiecesWithOffsets;
+use crate::input::Tokenize;
 
 /// BERT word piece tokenizer.
 ///
@@ -35,7 +36,7 @@ impl BertTokenizer {
 }
 
 impl Tokenize for BertTokenizer {
-    fn tokenize(&self, sentence: Sentence) -> SentenceWithPieces {
+    fn tokenize_(&self, sentence: &Sentence) -> PiecesWithOffsets {
         // An average of three pieces per token ought to enough for
         // everyone ;).
         let mut pieces = Vec::with_capacity((sentence.len() - 1) * 3);
@@ -59,9 +60,8 @@ impl Tokenize for BertTokenizer {
             }
         }
 
-        SentenceWithPieces {
+        PiecesWithOffsets {
             pieces: pieces.into(),
-            sentence,
             token_offsets,
         }
     }

--- a/syntaxdot/src/input/mod.rs
+++ b/syntaxdot/src/input/mod.rs
@@ -1,5 +1,5 @@
 use conllu::graph::Sentence;
-use ndarray::Array1;
+use ndarray::{Array1, ArrayView1};
 
 mod albert;
 pub use albert::AlbertTokenizer;
@@ -8,22 +8,121 @@ mod bert;
 pub use bert::BertTokenizer;
 
 mod xlm_roberta;
+use std::ops::{Deref, DerefMut};
 pub use xlm_roberta::XlmRobertaTokenizer;
 
 /// Trait for wordpiece tokenizers.
 pub trait Tokenize: Send + Sync {
+    /// Tokenize a sentence into word pieces.
+    #[doc(hidden)]
+    fn tokenize_(&self, sentence: &Sentence) -> pieces::PiecesWithOffsets;
+
     /// Tokenize the tokens in a sentence into word pieces.
-    fn tokenize(&self, sentence: Sentence) -> SentenceWithPieces;
+    ///
+    /// This method takes ownership of the sentence. Use `tokenize_mut` to
+    /// store a reference to the sentence.
+    fn tokenize(&self, sentence: Sentence) -> SentenceWithPieces<'static> {
+        let pieces_offsets = self.tokenize_(&sentence);
+        SentenceWithPieces {
+            pieces: pieces_offsets.pieces,
+            sentence: OwnedOrBorrowed::Owned(sentence),
+            token_offsets: pieces_offsets.token_offsets,
+        }
+    }
+
+    /// Tokenize the tokens in a sentence into word pieces.
+    ///
+    /// This method takes modified a sentence in-place.
+    fn tokenize_mut<'a>(&self, sentence: &'a mut Sentence) -> SentenceWithPieces<'a> {
+        let pieces_offsets = self.tokenize_(sentence);
+        SentenceWithPieces {
+            pieces: pieces_offsets.pieces,
+            sentence: OwnedOrBorrowed::Borrowed(sentence),
+            token_offsets: pieces_offsets.token_offsets,
+        }
+    }
 }
 
 /// A sentence and its word pieces.
-pub struct SentenceWithPieces {
+pub struct SentenceWithPieces<'a> {
     /// Word pieces in a sentence.
-    pub pieces: Array1<i64>,
+    pieces: Array1<i64>,
 
     /// Sentence graph.
-    pub sentence: Sentence,
+    sentence: OwnedOrBorrowed<'a, Sentence>,
 
     /// The the offsets of tokens in `pieces`.
-    pub token_offsets: Vec<usize>,
+    token_offsets: Vec<usize>,
+}
+
+impl<'a> SentenceWithPieces<'a> {
+    /// Get the word piece indices.
+    pub fn pieces(&self) -> ArrayView1<i64> {
+        self.pieces.view()
+    }
+
+    /// Get the sentence graph.
+    pub fn sentence(&self) -> &Sentence {
+        &self.sentence
+    }
+
+    pub fn sentence_mut(&mut self) -> &mut Sentence {
+        &mut self.sentence
+    }
+
+    /// Get the token offsets.
+    pub fn token_offsets(&self) -> &[usize] {
+        &self.token_offsets
+    }
+
+    /// Decompose the data structure into its parts.
+    ///
+    /// Returns the sentence, the word piece indices, and the token offsets.
+    pub fn into_parts(self) -> (Sentence, Array1<i64>, Vec<usize>) {
+        (
+            match self.sentence {
+                OwnedOrBorrowed::Owned(sent) => sent,
+                OwnedOrBorrowed::Borrowed(sent) => sent.clone(),
+            },
+            self.pieces,
+            self.token_offsets,
+        )
+    }
+}
+
+/// Owned or borrowed data.
+///
+/// We can't use `Cow`, since it does not support mutable references.
+enum OwnedOrBorrowed<'a, T: 'a> {
+    Owned(T),
+    Borrowed(&'a mut T),
+}
+
+impl<'a, T> Deref for OwnedOrBorrowed<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            OwnedOrBorrowed::Owned(v) => &v,
+            OwnedOrBorrowed::Borrowed(v) => *v,
+        }
+    }
+}
+
+impl<'a, T> DerefMut for OwnedOrBorrowed<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        match self {
+            OwnedOrBorrowed::Owned(ref mut v) => v,
+            OwnedOrBorrowed::Borrowed(v) => *v,
+        }
+    }
+}
+
+pub(crate) mod pieces {
+    use ndarray::Array1;
+
+    pub struct PiecesWithOffsets {
+        pub pieces: Array1<i64>,
+        pub token_offsets: Vec<usize>,
+    }
 }

--- a/syntaxdot/src/input/xlm_roberta.rs
+++ b/syntaxdot/src/input/xlm_roberta.rs
@@ -1,7 +1,8 @@
 use conllu::graph::{Node, Sentence};
 use sentencepiece::SentencePieceProcessor;
 
-use crate::input::{SentenceWithPieces, Tokenize};
+use crate::input::pieces::PiecesWithOffsets;
+use crate::input::Tokenize;
 
 const FAIRSEQ_BOS_ID: i64 = 0;
 const FAIRSEQ_EOS_ID: i64 = 2;
@@ -31,7 +32,7 @@ impl From<SentencePieceProcessor> for XlmRobertaTokenizer {
 }
 
 impl Tokenize for XlmRobertaTokenizer {
-    fn tokenize(&self, sentence: Sentence) -> SentenceWithPieces {
+    fn tokenize_(&self, sentence: &Sentence) -> PiecesWithOffsets {
         // An average of three pieces per token ought to be enough for
         // everyone ;).
         let mut pieces = Vec::with_capacity((sentence.len() - 1) * 3);
@@ -67,9 +68,8 @@ impl Tokenize for XlmRobertaTokenizer {
 
         pieces.push(FAIRSEQ_EOS_ID);
 
-        SentenceWithPieces {
+        PiecesWithOffsets {
             pieces: pieces.into(),
-            sentence,
             token_offsets,
         }
     }


### PR DESCRIPTION
Before this change `SentenceWithPieces` always contained an owned
`Sentence`. With this change, `SentenceWithPieces` can also hold
a mutable reference to a `Sentence`.

In order to support this in the `Tokenize` trait, it now has
two method:

- `tokenize`: takes ownership of a `Sentence` and stores it in
  the returned `SentenceWithPieces`.
- `tokenize_mut`: takes a mutable reference to `Sentence` and
  stores it in `SentenceWithPieces`.

Ideally, we would always use references. Unfortunately, this
does not work for iterators with `SentenceWithPieces` items.