### PR TITLE
distill: add the `attention-loss` option

### DIFF
--- a/syntaxdot-transformers/src/models/bert/mod.rs
+++ b/syntaxdot-transformers/src/models/bert/mod.rs
@@ -359,7 +359,7 @@ pub struct BertLayerOutput {
     /// The output of the layer.
     pub output: Tensor,
 
-    /// The layer attentions.
+    /// The layer attention scores (unnormalized).
     pub attention: Option<Tensor>,
 }
 
@@ -516,7 +516,7 @@ impl BertSelfAttention {
         );
         let context_layer = context_layer.view_(&new_context_layer_shape);
 
-        (context_layer, attention_probs)
+        (context_layer, attention_scores)
     }
 
     fn transpose_for_scores(&self, x: &Tensor) -> Tensor {

--- a/syntaxdot-transformers/src/models/squeeze_bert/mod.rs
+++ b/syntaxdot-transformers/src/models/squeeze_bert/mod.rs
@@ -292,7 +292,7 @@ impl SqueezeBertSelfAttention {
 
         let context_layer = self.transpose_output(&context_layer);
 
-        (context_layer, attention_probs)
+        (context_layer, attention_scores)
     }
 
     fn transpose_for_scores(&self, x: &Tensor) -> Tensor {

--- a/syntaxdot/src/model/bert.rs
+++ b/syntaxdot/src/model/bert.rs
@@ -344,7 +344,7 @@ impl BertModel {
     }
 
     /// Encode an input.
-    fn encode(
+    pub fn encode(
         &self,
         inputs: &Tensor,
         attention_mask: &Tensor,
@@ -391,6 +391,22 @@ impl BertModel {
     ) -> HashMap<String, Tensor> {
         let encoding = self.encode(inputs, attention_mask, train, freeze_layers);
         self.seq_classifiers.forward_t(&encoding, train)
+    }
+
+    /// Compute the logits for a batch of inputs from the transformer's encoding.
+    ///
+    /// * `attention_mask`: specifies which sequence elements should
+    ///    be masked when applying the encoder.
+    /// * `train`: indicates whether this forward pass will be used
+    ///   for backpropagation.
+    /// * `freeze_embeddings`: exclude embeddings from backpropagation.
+    /// * `freeze_encoder`: exclude the encoder from backpropagation.
+    pub fn logits_from_encoding(
+        &self,
+        layer_outputs: &[BertLayerOutput],
+        train: bool,
+    ) -> HashMap<String, Tensor> {
+        self.seq_classifiers.forward_t(layer_outputs, train)
     }
 
     /// Compute the loss given a batch of inputs and target labels.


### PR DESCRIPTION
Enabling this option adds the mean squared error (MSE) of the teacher
and student attentions to the loss. This can speed up convergence,
because the student learns to attend to the same pieces as the teacher.

Attention loss can only be computed when the teacher and student have
the same sequence lengths. This means practically that they should use
the same piece tokenizers.