### PR TITLE
Ingest edit_tree crate in syntaxdot-encoders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,18 +466,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3"
 
 [[package]]
-name = "edit_tree"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2b55ba8d3091e69abec7aebee0667da7c56910fc60ac9f2ec21d603a2768ce6"
-dependencies = [
- "lazy_static",
- "seqalign",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "either"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1640,7 +1628,6 @@ dependencies = [
  "approx",
  "conllu",
  "criterion",
- "edit_tree",
  "hdf5",
  "maplit",
  "ndarray",
@@ -1687,12 +1674,12 @@ name = "syntaxdot-encoders"
 version = "0.1.0"
 dependencies = [
  "conllu",
- "edit_tree",
  "lazy_static",
  "numberer",
  "ohnomore",
  "ordered-float",
  "petgraph",
+ "seqalign",
  "serde",
  "serde_derive",
  "thiserror",

--- a/syntaxdot-encoders/Cargo.toml
+++ b/syntaxdot-encoders/Cargo.toml
@@ -11,12 +11,12 @@ license = "BlueOak-1.0.0"
 
 [dependencies]
 conllu = "0.5"
-edit_tree = "0.1.1"
 numberer = "0.2"
 lazy_static = "1"
 ohnomore = "0.2.2"
 ordered-float = "1"
 petgraph = "0.5"
+seqalign = "0.2"
 serde = "1"
 serde_derive = "1"
 thiserror = "1"

--- a/syntaxdot-encoders/src/lemma/edit_tree.rs
+++ b/syntaxdot-encoders/src/lemma/edit_tree.rs
@@ -1,226 +1,371 @@
-use std::convert::Infallible;
+// Copyright 2019 The edit_tree contributors
+// Copyright 2020 TensorDot
+//
+// edit_tree is provided to you by its contributors under the Blue Oak Model License
+// Version 1.0.0 (see LICENSE.md). Tobias Pütz and Daniël de Kok may individually,
+// at their own discretion, relicense future versions of edit_tree under any later
+// version of the Blue Oak Model License.
+//
+// Contributors:
+//
+// Tobias Pütz <tobias.puetz@uni-tuebingen.de>
+// Daniël de Kok <me@danieldk.eu>
 
-use conllu::graph::{Node, Sentence};
-use edit_tree::{Apply, EditTree};
+//! Edit trees
+
+use std::cmp::Eq;
+use std::cmp::Ordering;
+use std::fmt::Debug;
+
+use lazy_static::lazy_static;
+use seqalign::measures::LCSOp;
+use seqalign::measures::LCS;
+use seqalign::op::IndexedOperation;
+use seqalign::Align;
 use serde::{Deserialize, Serialize};
 
-use crate::lemma::EncodeError;
-use crate::{EncodingProb, SentenceDecoder, SentenceEncoder};
-
-/// Back-off strategy.
-///
-/// This is the strategy that will be used when an edit tree
-/// could not be applied.
-#[serde(rename_all = "lowercase")]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub enum BackoffStrategy {
-    Nothing,
-    Form,
+lazy_static! {
+    static ref MEASURE: LCS = LCS::new(1, 1);
 }
 
-/// Edit tree-based lemma encoder.
-///
-/// This encoder encodes a lemma as an edit tree that is applied to an
-/// unlemmatized form.
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
-pub struct EditTreeEncoder {
-    backoff_strategy: BackoffStrategy,
+/// Enum representing a `TreeNode` of an `Graph<TreeNode<T>,Place>`.
+#[derive(Debug, PartialEq, Hash, Eq, Clone, Serialize, Deserialize)]
+pub enum EditTree {
+    MatchNode {
+        pre: usize,
+        suf: usize,
+        left: Option<Box<EditTree>>,
+        right: Option<Box<EditTree>>,
+    },
+
+    ReplaceNode {
+        replacee: Vec<char>,
+        replacement: Vec<char>,
+    },
 }
 
-impl EditTreeEncoder {
-    pub fn new(backoff_strategy: BackoffStrategy) -> Self {
-        EditTreeEncoder { backoff_strategy }
+impl EditTree {
+    /// Returns a edit tree specifying how to derive `b` from `a`.
+    ///
+    /// **Caution:** when using with stringy types. UTF-8 multi byte
+    /// chars will not be treated well. Consider passing in &[char]
+    /// instead.
+    pub fn create_tree(a: &[char], b: &[char]) -> Option<Self> {
+        build_tree(a, b).map(|tree| *tree)
     }
-}
 
-impl SentenceDecoder for EditTreeEncoder {
-    type Encoding = EditTree<char>;
+    /// Recursively applies the nodes stored in the edit tree. Returns `None` if the tree is not applicable to
+    /// `form`.
+    pub fn apply(&self, form: &[char]) -> Option<Vec<char>> {
+        let form_len = form.len();
+        match self {
+            EditTree::MatchNode {
+                pre,
+                suf,
+                left,
+                right,
+            } => {
+                if pre + suf >= form_len {
+                    return None;
+                }
 
-    type Error = Infallible;
+                let mut left = match left {
+                    Some(left) => left.apply(&form[..*pre])?,
+                    None => vec![],
+                };
 
-    fn decode<S>(&self, labels: &[S], sentence: &mut Sentence) -> Result<(), Self::Error>
-    where
-        S: AsRef<[EncodingProb<Self::Encoding>]>,
-    {
-        assert_eq!(
-            labels.len(),
-            sentence.len() - 1,
-            "Labels and sentence length mismatch"
-        );
+                left.extend(form[*pre..form_len - *suf].iter().cloned());
 
-        for (token, token_labels) in sentence
-            .iter_mut()
-            .filter_map(Node::token_mut)
-            .zip(labels.iter())
-        {
-            if let Some(label) = token_labels.as_ref().get(0) {
-                let form = token.form().chars().collect::<Vec<_>>();
+                if let Some(right) = right {
+                    left.extend(right.apply(&form[form_len - *suf..])?)
+                }
 
-                if let Some(lemma) = label.encoding().apply(&form) {
-                    // If the edit script can be applied, use the
-                    // resulting lemma...
-                    let lemma = lemma.into_iter().collect::<String>();
-                    token.set_lemma(Some(lemma));
-                } else if let BackoffStrategy::Form = self.backoff_strategy {
-                    // .. if the edit script failed and the back-off
-                    // strategy is to set the form as the lemma,
-                    // do so.
-                    token.set_lemma(Some(token.form().to_owned()));
+                Some(left)
+            }
+
+            EditTree::ReplaceNode {
+                ref replacee,
+                ref replacement,
+            } => {
+                if form == &replacee[..] || replacee.is_empty() {
+                    Some(replacement.clone())
+                } else {
+                    None
                 }
             }
         }
-
-        Ok(())
     }
 }
 
-impl SentenceEncoder for EditTreeEncoder {
-    type Encoding = EditTree<char>;
+/// Struct representing a continuous match between two sequences.
+#[derive(Debug, PartialEq, Eq, Hash)]
+struct LCSMatch {
+    start_src: usize,
+    start_targ: usize,
+    length: usize,
+}
 
-    type Error = EncodeError;
-
-    fn encode(&self, sentence: &Sentence) -> Result<Vec<Self::Encoding>, Self::Error> {
-        let mut encoding = Vec::with_capacity(sentence.len() - 1);
-
-        for token in sentence.iter().filter_map(Node::token) {
-            let lemma = token
-                .lemma()
-                .or_else(|| {
-                    if token.form() == "_" {
-                        Some("_").to_owned()
-                    } else {
-                        None
-                    }
-                })
-                .ok_or_else(|| EncodeError::MissingLemma {
-                    form: token.form().to_owned(),
-                })?;
-
-            let edit_tree = EditTree::create_tree(
-                &token.form().chars().collect::<Vec<_>>(),
-                &lemma.chars().collect::<Vec<_>>(),
-            );
-
-            encoding.push(edit_tree);
+impl LCSMatch {
+    fn new(start_src: usize, start_targ: usize, length: usize) -> Self {
+        LCSMatch {
+            start_src,
+            start_targ,
+            length,
         }
-
-        Ok(encoding)
     }
+    fn empty() -> Self {
+        LCSMatch::new(0, 0, 0)
+    }
+}
+
+impl PartialOrd for LCSMatch {
+    fn partial_cmp(&self, other: &LCSMatch) -> Option<Ordering> {
+        Some(self.length.cmp(&other.length))
+    }
+}
+
+/// Returns the start and end index of the longest match. Returns none if no match is found.
+fn longest_match(script: &[IndexedOperation<LCSOp>]) -> Option<LCSMatch> {
+    let mut longest = LCSMatch::empty();
+
+    let mut script_slice = &script[..];
+    while !script_slice.is_empty() {
+        let op = &script_slice[0];
+
+        match op.operation() {
+            LCSOp::Match => {
+                let in_start = op.source_idx();
+                let o_start = op.target_idx();
+                let end = match script_slice
+                    .iter()
+                    .position(|x| !matches!(x.operation(), LCSOp::Match))
+                {
+                    Some(idx) => idx,
+                    None => script_slice.len(),
+                };
+                if end > longest.length {
+                    longest = LCSMatch::new(in_start, o_start, end);
+                };
+
+                script_slice = &script_slice[end..];
+            }
+            _ => {
+                script_slice = &script_slice[1..];
+            }
+        }
+    }
+
+    if longest.length != 0 {
+        Some(longest)
+    } else {
+        None
+    }
+}
+
+/// Recursively builds an edit tree by applying itself to pre and suffix of the longest common substring.
+fn build_tree(form_ch: &[char], lem_ch: &[char]) -> Option<Box<EditTree>> {
+    if form_ch.is_empty() && lem_ch.is_empty() {
+        return None;
+    }
+
+    let alignment = MEASURE.align(&form_ch, &lem_ch);
+    let root = match longest_match(&alignment.edit_script()[..]) {
+        Some(m) => EditTree::MatchNode {
+            pre: m.start_src,
+            suf: (form_ch.len() - m.start_src) - m.length,
+            left: build_tree(&form_ch[..m.start_src], &lem_ch[..m.start_targ]),
+            right: build_tree(
+                &form_ch[m.start_src + m.length..],
+                &lem_ch[m.start_targ + m.length..],
+            ),
+        },
+        None => EditTree::ReplaceNode {
+            replacee: form_ch.to_vec(),
+            replacement: lem_ch.to_vec(),
+        },
+    };
+    Some(Box::new(root))
 }
 
 #[cfg(test)]
 mod tests {
-    use std::iter;
+    use std::collections::HashSet;
 
-    use conllu::graph::{Node, Sentence};
-    use conllu::token::{Token, TokenBuilder};
-    use edit_tree::EditTree as EditTreeInner;
+    use super::EditTree;
 
-    use super::{BackoffStrategy, EditTree, EditTreeEncoder};
-    use crate::{EncodingProb, SentenceDecoder, SentenceEncoder};
-
-    fn encode_and_wrap(
-        encoder: &EditTreeEncoder,
-        sent: &Sentence,
-    ) -> Vec<Vec<EncodingProb<EditTree<char>>>> {
-        encoder
-            .encode(&sent)
-            .unwrap()
-            .into_iter()
-            .map(|encoding| vec![EncodingProb::new(encoding, 1.0)])
-            .collect::<Vec<_>>()
+    /// Utility trait to retrieve a lower-cased `Vec<char>`.
+    pub trait ToLowerCharVec {
+        fn to_lower_char_vec(&self) -> Vec<char>;
     }
 
-    fn sentence_from_forms(tokens: &[&str]) -> Sentence {
-        tokens.iter().map(|t| Token::new(*t)).collect()
-    }
-
-    fn sentence_from_pairs(token_lemmas: &[(&str, &str)]) -> Sentence {
-        token_lemmas
-            .iter()
-            .map(|(t, l)| TokenBuilder::new(*t).lemma(*l).into())
-            .collect()
-    }
-
-    #[test]
-    fn display_edit_tree() {
-        let tree =
-            EditTreeInner::create_tree(&['l', 'o', 'o', 'p', 't'], &['l', 'o', 'p', 'e', 'n']);
-
-        assert_eq!(
-            tree.to_string(),
-            "(match 0 3 () (match 1 1 (replace \"o\" \"\") (replace \"t\" \"en\")))"
-        );
-    }
-
-    #[test]
-    fn encoder_decoder_roundtrip() {
-        let sent_encode =
-            sentence_from_pairs(&[("hij", "hij"), ("heeft", "hebben"), ("gefietst", "fietsen")]);
-
-        let encoder = EditTreeEncoder::new(BackoffStrategy::Nothing);
-        let labels = encode_and_wrap(&encoder, &sent_encode);
-
-        let mut sent_decode = sentence_from_forms(&["hij", "heeft", "gefietst"]);
-        encoder.decode(&labels, &mut sent_decode).unwrap();
-
-        assert_eq!(sent_encode, sent_decode);
-    }
-
-    #[test]
-    fn decoder_backoff_nothing() {
-        let sent_encode = sentence_from_pairs(&[
-            ("kinderen", "kind"),
-            ("hadden", "hebben"),
-            ("gefietst", "fietsen"),
-        ]);
-        let encoder = EditTreeEncoder::new(BackoffStrategy::Nothing);
-        let labels = encode_and_wrap(&encoder, &sent_encode);
-
-        let mut sent_decode = sentence_from_forms(&["het", "is", "anders"]);
-        encoder.decode(&labels, &mut sent_decode).unwrap();
-
-        assert!(sent_decode
-            .iter()
-            .filter_map(Node::token)
-            .map(Token::lemma)
-            .all(|lemma| lemma.is_none()));
-    }
-
-    #[test]
-    fn decoder_backoff_form() {
-        let sent_encode = sentence_from_pairs(&[
-            ("kinderen", "kind"),
-            ("hadden", "hebben"),
-            ("gefietst", "fietsen"),
-        ]);
-        let encoder = EditTreeEncoder::new(BackoffStrategy::Form);
-        let labels = encode_and_wrap(&encoder, &sent_encode);
-
-        let mut sent_decode = sentence_from_forms(&["het", "is", "anders"]);
-        encoder.decode(&labels, &mut sent_decode).unwrap();
-
-        for token in sent_decode.iter().filter_map(Node::token) {
-            assert_eq!(token.lemma(), Some(token.form()));
+    impl<'a> ToLowerCharVec for &'a str {
+        fn to_lower_char_vec(&self) -> Vec<char> {
+            self.to_lowercase().chars().collect()
         }
     }
 
     #[test]
-    fn handles_underscore_form_lemma() {
-        let sentence: Sentence = iter::once(TokenBuilder::new("_").into()).collect();
-        let encoder = EditTreeEncoder::new(BackoffStrategy::Form);
-        let labels = encode_and_wrap(&encoder, &sentence);
+    fn test_graph_equality_outcome() {
+        let a = "hates".to_lower_char_vec();
+        let b = "hate".to_lower_char_vec();
+        let g = EditTree::create_tree(&a, &b).unwrap();
 
-        let mut sent_decode = sentence_from_forms(&["_"]);
-        encoder.decode(&labels, &mut sent_decode).unwrap();
+        let a = "loves".to_lower_char_vec();
+        let b = "love".to_lower_char_vec();
+        let g1 = EditTree::create_tree(&a, &b).unwrap();
 
-        assert_eq!(sent_decode, sentence_from_pairs(&[("_", "_")]));
+        let f = "loves".to_lower_char_vec();
+        let f1 = "hates".to_lower_char_vec();
+        let exp = "love".to_lower_char_vec();
+        let exp1 = "hate".to_lower_char_vec();
+
+        assert_eq!(g.apply(&f1).unwrap(), exp1);
+        assert_eq!(g1.apply(&f).unwrap(), exp);
+        assert_eq!(g, g1);
     }
 
     #[test]
-    fn rejects_empty_lemma_with_nonempty_form() {
-        let sentence = sentence_from_forms(&["iets"]);
-        let encoder = EditTreeEncoder::new(BackoffStrategy::Nothing);
-        assert!(encoder.encode(&sentence).is_err());
+    fn test_graph_equality_outcome_2() {
+        let g = EditTree::create_tree(
+            &"machen".to_lower_char_vec(),
+            &"gemacht".to_lower_char_vec(),
+        )
+        .unwrap();
+        let g1 = EditTree::create_tree(
+            &"lachen".to_lower_char_vec(),
+            &"gelacht".to_lower_char_vec(),
+        )
+        .unwrap();
+
+        let f = "machen".to_lower_char_vec();
+        let f1 = "lachen".to_lower_char_vec();
+        let exp = "gemacht".to_lower_char_vec();
+        let exp1 = "gelacht".to_lower_char_vec();
+
+        assert_eq!(g.apply(&f1).unwrap(), exp1);
+        assert_eq!(g1.apply(&f).unwrap(), exp);
+        assert_eq!(g, g1);
+    }
+
+    #[test]
+    fn test_graph_equality_outcome_3() {
+        let a = "aaaaaaaaen".to_lower_char_vec();
+        let b = "geaaaaaaaat".to_lower_char_vec();
+        let g = EditTree::create_tree(&a, &b).unwrap();
+
+        let a = "lachen".to_lower_char_vec();
+        let b = "gelacht".to_lower_char_vec();
+        let g1 = EditTree::create_tree(&a, &b).unwrap();
+
+        let f = "lachen".to_lower_char_vec();
+        let f1 = "aaaaaaaaen".to_lower_char_vec();
+        let exp = "gelacht".to_lower_char_vec();
+        let exp1 = "geaaaaaaaat".to_lower_char_vec();
+
+        assert_eq!(g.apply(&f).unwrap(), exp);
+        assert_eq!(g1.apply(&f1).unwrap(), exp1);
+        assert_eq!(g, g1);
+    }
+
+    #[test]
+    fn test_graph_equality_and_applicability() {
+        let mut set: HashSet<EditTree> = HashSet::default();
+        let a = "abc".to_lower_char_vec();
+        let b = "ab".to_lower_char_vec();
+        let g1 = EditTree::create_tree(&a, &b).unwrap();
+
+        let a = "aaa".to_lower_char_vec();
+        let b = "aa".to_lower_char_vec();
+        let g2 = EditTree::create_tree(&a, &b).unwrap();
+
+        let a = "cba".to_lower_char_vec();
+        let b = "ba".to_lower_char_vec();
+        let g3 = EditTree::create_tree(&a, &b).unwrap();
+        let g4 = EditTree::create_tree(&a, &b).unwrap();
+
+        let a = "aaa".to_lower_char_vec();
+        let b = "aac".to_lower_char_vec();
+        let g5 = EditTree::create_tree(&a, &b).unwrap();
+
+        let a = "dec".to_lower_char_vec();
+        let b = "decc".to_lower_char_vec();
+        let g6 = EditTree::create_tree(&a, &a).unwrap();
+        let g7 = EditTree::create_tree(&a, &b).unwrap();
+
+        set.insert(g1);
+        assert_eq!(set.len(), 1);
+        set.insert(g2);
+        assert_eq!(set.len(), 2);
+        set.insert(g3);
+        assert_eq!(set.len(), 3);
+        set.insert(g4);
+        assert_eq!(set.len(), 3);
+        set.insert(g5);
+        assert_eq!(set.len(), 4);
+        set.insert(g6);
+        set.insert(g7);
+        assert_eq!(set.len(), 6);
+
+        let v = "yyyy".to_lower_char_vec();
+        let res: HashSet<String> = set
+            .iter()
+            .map(|x| x.apply(&v))
+            .filter(|x| x.is_some())
+            .map(|x| x.unwrap().iter().collect::<String>())
+            .collect();
+
+        assert_eq!(res.len(), 2);
+
+        let v = "yyy".to_lower_char_vec();
+        let res: HashSet<String> = set
+            .iter()
+            .map(|x| x.apply(&v))
+            .filter(|x| x.is_some())
+            .map(|x| x.unwrap().iter().collect::<String>())
+            .collect();
+        assert!(res.contains("yyyc"));
+        assert!(res.contains("yyy"));
+        assert_eq!(res.len(), 2);
+
+        let v = "bba".to_lower_char_vec();
+        let res: HashSet<String> = set
+            .iter()
+            .map(|x| x.apply(&v))
+            .filter(|x| x.is_some())
+            .map(|x| x.unwrap().iter().collect::<String>())
+            .collect();
+
+        assert!(res.contains("bbac"));
+        assert!(res.contains("bba"));
+        assert!(res.contains("bb"));
+        assert!(res.contains("bbc"));
+        assert_eq!(res.len(), 4);
+
+        let res: HashSet<String> = set
+            .iter()
+            .map(|x| x.apply(&a))
+            .filter(|x| x.is_some())
+            .map(|x| x.unwrap().iter().collect::<String>())
+            .collect();
+        assert!(res.contains("dec"));
+        assert!(res.contains("decc"));
+        assert!(res.contains("de"));
+        assert_eq!(res.len(), 3);
+
+        let a = "die".to_lower_char_vec();
+        let b = "das".to_lower_char_vec();
+        let c = "die".to_lower_char_vec();
+        let g = EditTree::create_tree(&a, &b).unwrap();
+        assert!(g.apply(&c).is_some());
+    }
+    #[test]
+    fn test_graphs_inapplicable() {
+        let g = EditTree::create_tree(&"abcdefg".to_lower_char_vec(), &"abc".to_lower_char_vec())
+            .unwrap();
+        assert!(g.apply(&"abc".to_lower_char_vec()).is_none());
+
+        let g = EditTree::create_tree(&"abcdefg".to_lower_char_vec(), &"efg".to_lower_char_vec())
+            .unwrap();
+        assert!(g.apply(&"efg".to_lower_char_vec()).is_none());
     }
 }

--- a/syntaxdot-encoders/src/lemma/encoder.rs
+++ b/syntaxdot-encoders/src/lemma/encoder.rs
@@ -1,0 +1,218 @@
+use std::convert::Infallible;
+
+use conllu::graph::{Node, Sentence};
+use serde::{Deserialize, Serialize};
+
+use crate::lemma::edit_tree::EditTree;
+use crate::lemma::EncodeError;
+use crate::{EncodingProb, SentenceDecoder, SentenceEncoder};
+
+/// Back-off strategy.
+///
+/// This is the strategy that will be used when an edit tree
+/// could not be applied.
+#[serde(rename_all = "lowercase")]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub enum BackoffStrategy {
+    Nothing,
+    Form,
+}
+
+/// Edit tree-based lemma encoder.
+///
+/// This encoder encodes a lemma as an edit tree that is applied to an
+/// unlemmatized form.
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+pub struct EditTreeEncoder {
+    backoff_strategy: BackoffStrategy,
+}
+
+impl EditTreeEncoder {
+    pub fn new(backoff_strategy: BackoffStrategy) -> Self {
+        EditTreeEncoder { backoff_strategy }
+    }
+}
+
+impl SentenceDecoder for EditTreeEncoder {
+    type Encoding = EditTree;
+
+    type Error = Infallible;
+
+    fn decode<S>(&self, labels: &[S], sentence: &mut Sentence) -> Result<(), Self::Error>
+    where
+        S: AsRef<[EncodingProb<Self::Encoding>]>,
+    {
+        assert_eq!(
+            labels.len(),
+            sentence.len() - 1,
+            "Labels and sentence length mismatch"
+        );
+
+        for (token, token_labels) in sentence
+            .iter_mut()
+            .filter_map(Node::token_mut)
+            .zip(labels.iter())
+        {
+            if let Some(label) = token_labels.as_ref().get(0) {
+                let form = token.form().chars().collect::<Vec<_>>();
+
+                if let Some(lemma) = label.encoding().apply(&form) {
+                    // If the edit script can be applied, use the
+                    // resulting lemma...
+                    let lemma = lemma.into_iter().collect::<String>();
+                    token.set_lemma(Some(lemma));
+                } else if let BackoffStrategy::Form = self.backoff_strategy {
+                    // .. if the edit script failed and the back-off
+                    // strategy is to set the form as the lemma,
+                    // do so.
+                    token.set_lemma(Some(token.form().to_owned()));
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl SentenceEncoder for EditTreeEncoder {
+    type Encoding = EditTree;
+
+    type Error = EncodeError;
+
+    fn encode(&self, sentence: &Sentence) -> Result<Vec<Self::Encoding>, Self::Error> {
+        let mut encoding = Vec::with_capacity(sentence.len() - 1);
+
+        for token in sentence.iter().filter_map(Node::token) {
+            let lemma = token
+                .lemma()
+                .or_else(|| {
+                    if token.form() == "_" {
+                        Some("_").to_owned()
+                    } else {
+                        None
+                    }
+                })
+                .ok_or_else(|| EncodeError::MissingLemma {
+                    form: token.form().to_owned(),
+                })?;
+
+            let edit_tree = EditTree::create_tree(
+                &token.form().chars().collect::<Vec<_>>(),
+                &lemma.chars().collect::<Vec<_>>(),
+            )
+            .ok_or_else(|| EncodeError::NoEditTree {
+                form: token.form().to_string(),
+                lemma: lemma.to_string(),
+            })?;
+
+            encoding.push(edit_tree);
+        }
+
+        Ok(encoding)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::iter;
+
+    use conllu::graph::{Node, Sentence};
+    use conllu::token::{Token, TokenBuilder};
+
+    use super::{BackoffStrategy, EditTree, EditTreeEncoder};
+    use crate::{EncodingProb, SentenceDecoder, SentenceEncoder};
+
+    fn encode_and_wrap(
+        encoder: &EditTreeEncoder,
+        sent: &Sentence,
+    ) -> Vec<Vec<EncodingProb<EditTree>>> {
+        encoder
+            .encode(&sent)
+            .unwrap()
+            .into_iter()
+            .map(|encoding| vec![EncodingProb::new(encoding, 1.0)])
+            .collect::<Vec<_>>()
+    }
+
+    fn sentence_from_forms(tokens: &[&str]) -> Sentence {
+        tokens.iter().map(|t| Token::new(*t)).collect()
+    }
+
+    fn sentence_from_pairs(token_lemmas: &[(&str, &str)]) -> Sentence {
+        token_lemmas
+            .iter()
+            .map(|(t, l)| TokenBuilder::new(*t).lemma(*l).into())
+            .collect()
+    }
+
+    #[test]
+    fn encoder_decoder_roundtrip() {
+        let sent_encode =
+            sentence_from_pairs(&[("hij", "hij"), ("heeft", "hebben"), ("gefietst", "fietsen")]);
+
+        let encoder = EditTreeEncoder::new(BackoffStrategy::Nothing);
+        let labels = encode_and_wrap(&encoder, &sent_encode);
+
+        let mut sent_decode = sentence_from_forms(&["hij", "heeft", "gefietst"]);
+        encoder.decode(&labels, &mut sent_decode).unwrap();
+
+        assert_eq!(sent_encode, sent_decode);
+    }
+
+    #[test]
+    fn decoder_backoff_nothing() {
+        let sent_encode = sentence_from_pairs(&[
+            ("kinderen", "kind"),
+            ("hadden", "hebben"),
+            ("gefietst", "fietsen"),
+        ]);
+        let encoder = EditTreeEncoder::new(BackoffStrategy::Nothing);
+        let labels = encode_and_wrap(&encoder, &sent_encode);
+
+        let mut sent_decode = sentence_from_forms(&["het", "is", "anders"]);
+        encoder.decode(&labels, &mut sent_decode).unwrap();
+
+        assert!(sent_decode
+            .iter()
+            .filter_map(Node::token)
+            .map(Token::lemma)
+            .all(|lemma| lemma.is_none()));
+    }
+
+    #[test]
+    fn decoder_backoff_form() {
+        let sent_encode = sentence_from_pairs(&[
+            ("kinderen", "kind"),
+            ("hadden", "hebben"),
+            ("gefietst", "fietsen"),
+        ]);
+        let encoder = EditTreeEncoder::new(BackoffStrategy::Form);
+        let labels = encode_and_wrap(&encoder, &sent_encode);
+
+        let mut sent_decode = sentence_from_forms(&["het", "is", "anders"]);
+        encoder.decode(&labels, &mut sent_decode).unwrap();
+
+        for token in sent_decode.iter().filter_map(Node::token) {
+            assert_eq!(token.lemma(), Some(token.form()));
+        }
+    }
+
+    #[test]
+    fn handles_underscore_form_lemma() {
+        let sentence: Sentence = iter::once(TokenBuilder::new("_").into()).collect();
+        let encoder = EditTreeEncoder::new(BackoffStrategy::Form);
+        let labels = encode_and_wrap(&encoder, &sentence);
+
+        let mut sent_decode = sentence_from_forms(&["_"]);
+        encoder.decode(&labels, &mut sent_decode).unwrap();
+
+        assert_eq!(sent_decode, sentence_from_pairs(&[("_", "_")]));
+    }
+
+    #[test]
+    fn rejects_empty_lemma_with_nonempty_form() {
+        let sentence = sentence_from_forms(&["iets"]);
+        let encoder = EditTreeEncoder::new(BackoffStrategy::Nothing);
+        assert!(encoder.encode(&sentence).is_err());
+    }
+}

--- a/syntaxdot-encoders/src/lemma/mod.rs
+++ b/syntaxdot-encoders/src/lemma/mod.rs
@@ -1,7 +1,10 @@
 use thiserror::Error;
 
+mod encoder;
+pub use self::encoder::{BackoffStrategy, EditTreeEncoder};
+
 mod edit_tree;
-pub use self::edit_tree::{BackoffStrategy, EditTreeEncoder};
+pub use edit_tree::EditTree;
 
 mod tdz;
 pub use tdz::TdzLemmaEncoder;
@@ -12,4 +15,8 @@ pub enum EncodeError {
     /// The token does not have a lemma.
     #[error("token without a lemma: '{form:?}'")]
     MissingLemma { form: String },
+
+    /// No edit tree can be constructed.
+    #[error("cannot find an edit tree that rewrites '{form:?}' into '{lemma:?}'")]
+    NoEditTree { form: String, lemma: String },
 }

--- a/syntaxdot-encoders/src/lemma/tdz.rs
+++ b/syntaxdot-encoders/src/lemma/tdz.rs
@@ -114,9 +114,9 @@ mod tests {
 
     use conllu::graph::{DepTriple, Sentence};
     use conllu::token::TokenBuilder;
-    use edit_tree::EditTree as EditTreeInner;
 
     use super::TdzLemmaEncoder;
+    use crate::lemma::edit_tree::EditTree as EditTreeInner;
     use crate::lemma::BackoffStrategy;
     use crate::{EncodingProb, SentenceDecoder, SentenceEncoder};
 
@@ -147,18 +147,19 @@ mod tests {
         sent
     }
 
-    fn sentence_edit_trees() -> Vec<EditTreeInner<char>> {
+    fn sentence_edit_trees() -> Vec<EditTreeInner> {
         vec![
-            EditTreeInner::create_tree(&['I', 'c', 'h'], &['i', 'c', 'h']),
-            EditTreeInner::create_tree(&['r', 'e', 'i', 's', 'e'], &['r', 'e', 'i', 's', 'e', 'n']),
-            EditTreeInner::create_tree(&['a', 'b'], &['a', 'b']),
+            EditTreeInner::create_tree(&['I', 'c', 'h'], &['i', 'c', 'h']).unwrap(),
+            EditTreeInner::create_tree(&['r', 'e', 'i', 's', 'e'], &['r', 'e', 'i', 's', 'e', 'n'])
+                .unwrap(),
+            EditTreeInner::create_tree(&['a', 'b'], &['a', 'b']).unwrap(),
         ]
     }
 
     fn encode_and_wrap(
         encoder: &TdzLemmaEncoder,
         sent: &Sentence,
-    ) -> Vec<Vec<EncodingProb<EditTreeInner<char>>>> {
+    ) -> Vec<Vec<EncodingProb<EditTreeInner>>> {
         encoder
             .encode(&sent)
             .unwrap()

--- a/syntaxdot/Cargo.toml
+++ b/syntaxdot/Cargo.toml
@@ -11,7 +11,6 @@ license = "BlueOak-1.0.0"
 
 [dependencies]
 conllu = "0.5"
-edit_tree = "0.1.1"
 hdf5 = { version = "0.7", optional = true }
 ndarray = "0.13"
 numberer = "0.2"

--- a/syntaxdot/src/encoders/encoders.rs
+++ b/syntaxdot/src/encoders/encoders.rs
@@ -2,7 +2,6 @@ use std::hash::Hash;
 use std::ops::Deref;
 
 use conllu::graph::Sentence;
-use edit_tree::EditTree;
 use numberer::Numberer;
 use serde::{Deserialize, Serialize};
 use syntaxdot_encoders::categorical::{ImmutableCategoricalEncoder, MutableCategoricalEncoder};
@@ -10,7 +9,7 @@ use syntaxdot_encoders::deprel::{
     DependencyEncoding, RelativePOS, RelativePOSEncoder, RelativePosition, RelativePositionEncoder,
 };
 use syntaxdot_encoders::layer::LayerEncoder;
-use syntaxdot_encoders::lemma::{EditTreeEncoder, TdzLemmaEncoder};
+use syntaxdot_encoders::lemma::{EditTree, EditTreeEncoder, TdzLemmaEncoder};
 use syntaxdot_encoders::{EncodingProb, SentenceDecoder, SentenceEncoder};
 use thiserror::Error;
 
@@ -125,13 +124,13 @@ pub enum EncoderError {
 /// Wrapper of the various supported encoders.
 #[derive(Deserialize, Serialize)]
 pub enum Encoder {
-    Lemma(CategoricalEncoderWrap<EditTreeEncoder, EditTree<char>>),
+    Lemma(CategoricalEncoderWrap<EditTreeEncoder, EditTree>),
     Layer(CategoricalEncoderWrap<LayerEncoder, String>),
     RelativePOS(CategoricalEncoderWrap<RelativePOSEncoder, DependencyEncoding<RelativePOS>>),
     RelativePosition(
         CategoricalEncoderWrap<RelativePositionEncoder, DependencyEncoding<RelativePosition>>,
     ),
-    TdzLemma(CategoricalEncoderWrap<TdzLemmaEncoder, EditTree<char>>),
+    TdzLemma(CategoricalEncoderWrap<TdzLemmaEncoder, EditTree>),
 }
 
 #[allow(clippy::len_without_is_empty)]


### PR DESCRIPTION
- The crate is small and this allows us to make changes without
  waiting for crates.io uploads.
- Remove code that we do not need in syntaxdot-encoders.
- Some small cleanups.
