### PR TITLE
Fix tokenizer model tests

### DIFF
--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -39,6 +39,6 @@ for var in "${!models[@]}"; do
   declare -x "${var}"="${data}"
 done
 
-( cd syntaxdot-transformers ; cargo test --features model-tests )
+( cd syntaxdot-tokenizers ; cargo test --features model-tests )
 
-( cd syntaxdot ; cargo test --features model-tests )
+( cd syntaxdot-transformers ; cargo test --features model-tests )

--- a/syntaxdot-tokenizers/Cargo.toml
+++ b/syntaxdot-tokenizers/Cargo.toml
@@ -15,3 +15,6 @@ ndarray = "0.13"
 sentencepiece = "0.5"
 thiserror = "1"
 wordpieces = "0.4"
+
+[features]
+model-tests = []

--- a/syntaxdot-tokenizers/src/albert.rs
+++ b/syntaxdot-tokenizers/src/albert.rs
@@ -98,7 +98,8 @@ mod tests {
     use ndarray::array;
     use sentencepiece::SentencePieceProcessor;
 
-    use crate::input::{AlbertTokenizer, Tokenize};
+    use super::AlbertTokenizer;
+    use crate::Tokenize;
 
     fn sentence_from_forms(forms: &[&str]) -> Sentence {
         Sentence::from_iter(forms.iter().map(|&f| Token::new(f)))

--- a/syntaxdot-tokenizers/src/bert.rs
+++ b/syntaxdot-tokenizers/src/bert.rs
@@ -107,7 +107,8 @@ mod tests {
     use ndarray::array;
     use wordpieces::WordPieces;
 
-    use crate::input::{BertTokenizer, Tokenize};
+    use super::BertTokenizer;
+    use crate::Tokenize;
 
     fn read_pieces() -> WordPieces {
         let f = File::open(env!("BERT_BASE_GERMAN_CASED_VOCAB")).unwrap();

--- a/syntaxdot-tokenizers/src/xlm_roberta.rs
+++ b/syntaxdot-tokenizers/src/xlm_roberta.rs
@@ -96,7 +96,8 @@ mod tests {
     use ndarray::array;
     use sentencepiece::SentencePieceProcessor;
 
-    use crate::input::{Tokenize, XlmRobertaTokenizer};
+    use super::XlmRobertaTokenizer;
+    use crate::Tokenize;
 
     fn sentence_from_forms(forms: &[&str]) -> Sentence {
         Sentence::from_iter(forms.iter().map(|&f| Token::new(f)))

--- a/syntaxdot/Cargo.toml
+++ b/syntaxdot/Cargo.toml
@@ -37,7 +37,6 @@ ndarray-rand = "0.11"
 [features]
 default = ["load-hdf5"]
 load-hdf5 = ["syntaxdot-transformers/load-hdf5", "hdf5"]
-model-tests = []
 
 [[bench]]
 name = "mst"


### PR DESCRIPTION
These were not properly migrated when the tokenizers were moved to the
syntaxdot-tokenizers crate.
