### PR TITLE
Require tokenizers to add a BOS piece

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## [Unreleased]
+
+### Changed
+
+- Implementations of `Tokenizer` are now required to put a piece that marks the
+  beginning of a sentence before the first token piece. `BertTokenizer` was the
+  only tokenizer that did not fulfill this requirement. `BertTokenizer` is
+  updated to insert the `[CLS]` piece as a beginning of sentence marker.
+  **Warning:** this breaks existing models with `tokenizer = "bert"`, which should
+  be retrained.

--- a/syntaxdot-tokenizers/src/bert.rs
+++ b/syntaxdot-tokenizers/src/bert.rs
@@ -68,6 +68,12 @@ impl Tokenize for BertTokenizer {
         let mut pieces = Vec::with_capacity((sentence.len() - 1) * 3);
         let mut token_offsets = Vec::with_capacity(sentence.len());
 
+        pieces.push(
+            self.word_pieces
+                .get_initial("[CLS]")
+                .expect("BERT model does not have a [CLS] token") as i64,
+        );
+
         for token in sentence.iter().filter_map(Node::token) {
             token_offsets.push(pieces.len());
 
@@ -128,8 +134,8 @@ mod tests {
         let sentence_pieces = tokenizer.tokenize(sentence);
         assert_eq!(
             sentence_pieces.pieces,
-            array![133i64, 1937, 14010, 30, 32, 26939, 26962, 12558, 2739, 2]
+            array![3i64, 133, 1937, 14010, 30, 32, 26939, 26962, 12558, 2739, 2]
         );
-        assert_eq!(sentence_pieces.token_offsets, &[0, 3, 4, 7, 9]);
+        assert_eq!(sentence_pieces.token_offsets, &[1, 4, 5, 8, 10]);
     }
 }

--- a/syntaxdot-tokenizers/src/lib.rs
+++ b/syntaxdot-tokenizers/src/lib.rs
@@ -16,6 +16,12 @@ pub use xlm_roberta::XlmRobertaTokenizer;
 /// Trait for wordpiece tokenizers.
 pub trait Tokenize: Send + Sync {
     /// Tokenize the tokens in a sentence into word pieces.
+    ///
+    /// Implementations **must** prefix the first piece corresponding to a
+    /// token by one or more special pieces marking the beginning of the
+    /// sentence. The representation of this piece can be used for special
+    /// purposes, such as classification or acting is the pseudo-root in
+    /// dependency parsing.
     fn tokenize(&self, sentence: Sentence) -> SentenceWithPieces;
 }
 


### PR DESCRIPTION
Implementations of `Tokenizer` are now required to put a piece that marks the
beginning of a sentence before the first token piece. `BertTokenizer` was the
only tokenizer that did not fulfill this requirement. `BertTokenizer` is
updated to insert the `[CLS]` piece as a beginning of sentence marker.
**Warning:** this breaks existing models with `tokenizer = "bert"`,
which should be retrained.