### PR TITLE
Add basic support for token pooling

### DIFF
--- a/syntaxdot-cli/src/io.rs
+++ b/syntaxdot-cli/src/io.rs
@@ -95,6 +95,7 @@ impl Model {
                 .map(ImmutableDependencyEncoder::n_relations)
                 .unwrap_or(0),
             &encoders,
+            config.model.pooler,
             0.0,
             config.model.position_embeddings,
         )

--- a/syntaxdot-transformers/src/loss.rs
+++ b/syntaxdot-transformers/src/loss.rs
@@ -1,5 +1,6 @@
+use tch::{Kind, Reduction, Tensor};
+
 use crate::TransformerError;
-use tch::{Reduction, Tensor};
 
 trait Reduce {
     type Error;
@@ -46,9 +47,18 @@ impl CrossEntropyLoss {
     /// Compute the cross-entropy loss.
     ///
     /// `logits` should be the unnormalized probablilities of shape
-    /// `[batch_size, seq_len]` and `targets` the gold-standard labels
+    /// `[batch_size, n_classes]` and `targets` the gold-standard labels
     /// with shape `[batch_size]`.
-    pub fn forward(&self, logits: &Tensor, targets: &Tensor) -> Result<Tensor, TransformerError> {
+    ///
+    /// The optional target mask has to be of shape `[batch_size, n_classes]`.
+    /// If the mask is not provided, then all `n_classes` will be used in
+    /// label smoothing.
+    pub fn forward(
+        &self,
+        logits: &Tensor,
+        targets: &Tensor,
+        target_mask: Option<&Tensor>,
+    ) -> Result<Tensor, TransformerError> {
         let (_, n_classes) = logits.size2()?;
         let log_probs = logits.f_log_softmax(-1, logits.kind())?;
 
@@ -61,13 +71,30 @@ impl CrossEntropyLoss {
                     targets.f_where3(&targets.f_ne(self.ignore_index)?, 0)?;
 
                 // Set all labels to label_smoothing and the target to 1-label_smoothing.
-                let smoothed_targets = tch::no_grad(|| {
-                    Tensor::f_full_like(&log_probs, label_smoothing / (n_classes - 1) as f64)?
-                        .f_scatter1(
-                            1,
-                            &targets_non_negative.f_unsqueeze(1)?,
-                            1. - label_smoothing,
-                        )
+                let smoothed_targets = tch::no_grad(|| match target_mask {
+                    None => {
+                        Tensor::f_full_like(&log_probs, label_smoothing / (n_classes - 1) as f64)?
+                            .f_scatter1(
+                                1,
+                                &targets_non_negative.f_unsqueeze(1)?,
+                                1. - label_smoothing,
+                            )
+                    }
+                    Some(target_mask) => {
+                        let batch_probs = label_smoothing
+                            / target_mask.f_sum1(&[-1], false, Kind::Float)?.f_sub1(1)?;
+                        Tensor::f_zeros_like(&log_probs)?
+                            // Set label probabilities to batch smoothing probability.
+                            .f_add_(&batch_probs.f_unsqueeze(-1)?)?
+                            // Mask out padding.
+                            .f_mul(&target_mask.to_kind(Kind::Float))?
+                            // Assign probabilities to gold standard labels.
+                            .f_scatter1(
+                                1,
+                                &targets_non_negative.f_unsqueeze(1)?,
+                                1. - label_smoothing,
+                            )
+                    }
                 })?;
                 let losses = (smoothed_targets.f_neg()?.f_mul(&log_probs)?).f_sum1(
                     &[-1],
@@ -102,7 +129,7 @@ mod tests {
         let logits = Tensor::of_slice(&[-1., -1., 1., -1., -1.]).view([1, 5]);
         let targets = Tensor::of_slice(&[2i64]).view([1]);
         let cross_entropy_loss = CrossEntropyLoss::new(-1, None, Reduction::None);
-        let loss: ArrayD<f32> = (&cross_entropy_loss.forward(&logits, &targets).unwrap())
+        let loss: ArrayD<f32> = (&cross_entropy_loss.forward(&logits, &targets, None).unwrap())
             .try_into()
             .unwrap();
 
@@ -114,7 +141,21 @@ mod tests {
         let logits = Tensor::of_slice(&[-1., -1., 1., -1., -1.]).view([1, 5]);
         let targets = Tensor::of_slice(&[2i64]).view([1]);
         let cross_entropy_loss = CrossEntropyLoss::new(-1, Some(0.1), Reduction::None);
-        let loss: ArrayD<f32> = (&cross_entropy_loss.forward(&logits, &targets).unwrap())
+        let loss: ArrayD<f32> = (&cross_entropy_loss.forward(&logits, &targets, None).unwrap())
+            .try_into()
+            .unwrap();
+        assert_abs_diff_eq!(loss, array![0.632653].into_dyn(), epsilon = 1e-6);
+    }
+
+    #[test]
+    fn cross_entropy_with_label_smoothing_and_mask() {
+        let logits = Tensor::of_slice(&[-1., -1., 1., -1., -1.]).view([1, 5]);
+        let target_mask = Tensor::of_slice(&[true, false, true, false, true]).view([1, 5]);
+        let targets = Tensor::of_slice(&[2i64]).view([1]);
+        let cross_entropy_loss = CrossEntropyLoss::new(-1, Some(0.1), Reduction::None);
+        let loss: ArrayD<f32> = (&cross_entropy_loss
+            .forward(&logits, &targets, Some(&target_mask))
+            .unwrap())
             .try_into()
             .unwrap();
         assert_abs_diff_eq!(loss, array![0.632653].into_dyn(), epsilon = 1e-6);

--- a/syntaxdot-transformers/src/scalar_weighting.rs
+++ b/syntaxdot-transformers/src/scalar_weighting.rs
@@ -247,7 +247,7 @@ impl ScalarWeightClassifier {
         let predicted = logits.f_argmax(-1, false)?;
 
         let losses = CrossEntropyLoss::new(-1, label_smoothing, Reduction::None)
-            .forward(&logits, &targets)?
+            .forward(&logits, &targets, None)?
             .f_view([batch_size, seq_len])?;
 
         Ok((

--- a/syntaxdot/src/config.rs
+++ b/syntaxdot/src/config.rs
@@ -3,6 +3,7 @@ use std::io::{BufReader, Read};
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
+use syntaxdot_encoders::dependency::MutableDependencyEncoder;
 use syntaxdot_tokenizers::{AlbertTokenizer, BertTokenizer, Tokenize, XlmRobertaTokenizer};
 use syntaxdot_transformers::models::albert::AlbertConfig;
 use syntaxdot_transformers::models::bert::BertConfig;
@@ -11,7 +12,7 @@ use syntaxdot_transformers::models::squeeze_bert::SqueezeBertConfig;
 
 use crate::encoders::EncodersConfig;
 use crate::error::SyntaxDotError;
-use syntaxdot_encoders::dependency::MutableDependencyEncoder;
+use crate::model::pooling::PiecePooler;
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(deny_unknown_fields, rename = "biaffine")]
@@ -66,6 +67,9 @@ pub struct Labeler {
 pub struct Model {
     /// Model parameters.
     pub parameters: String,
+
+    /// Pooler for token representations.
+    pub pooler: PiecePooler,
 
     /// Configuration of position embeddings.
     pub position_embeddings: PositionEmbeddings,
@@ -324,6 +328,7 @@ mod tests {
         PretrainModelType, Tokenizer, TomlRead,
     };
     use crate::encoders::{EncoderType, EncodersConfig, NamedEncoderConfig};
+    use crate::model::pooling::PiecePooler;
 
     #[test]
     fn config() {
@@ -366,6 +371,7 @@ mod tests {
                 },
                 model: Model {
                     parameters: "epoch-99".to_string(),
+                    pooler: PiecePooler::Discard,
                     position_embeddings: PositionEmbeddings::Model,
                     pretrain_config: "bert_config.json".to_string(),
                     pretrain_type: PretrainModelType::Bert,

--- a/syntaxdot/src/model/mod.rs
+++ b/syntaxdot/src/model/mod.rs
@@ -2,4 +2,6 @@ pub mod biaffine_dependency_layer;
 
 pub mod bert;
 
+pub(crate) mod pooling;
+
 pub mod seq_classifiers;

--- a/syntaxdot/src/model/pooling.rs
+++ b/syntaxdot/src/model/pooling.rs
@@ -1,0 +1,72 @@
+use serde::{Deserialize, Serialize};
+use syntaxdot_transformers::models::LayerOutput;
+use syntaxdot_transformers::TransformerError;
+use tch::Tensor;
+
+use crate::error::SyntaxDotError;
+
+/// Word/sentence piece pooler.
+///
+/// The models that are used in SyntaxDot use word or sentence pieces.
+/// After piece tokenization, each token is represented by one initial
+/// piece, followed by zero or more continuation pieces. However, in
+/// sequence labeling and dependency parsing, each token must be
+/// represented using a single vector (in each layer).
+///
+/// The pooler combines the one or more piece representations into
+/// a single representation using pooling.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PiecePooler {
+    /// Discard continuation pieces.
+    Discard,
+}
+
+impl PiecePooler {
+    /// Pool pieces in all layers.
+    pub fn pool(
+        &self,
+        token_offsets: &Tensor,
+        layer_outputs: &[LayerOutput],
+    ) -> Result<Vec<LayerOutput>, SyntaxDotError> {
+        let mut new_layer_outputs = Vec::with_capacity(layer_outputs.len());
+        for layer_output in layer_outputs {
+            let new_layer_output = layer_output
+                .map_output(|output| self.pool_layer(token_offsets, output))
+                .map_err(SyntaxDotError::BertError)?;
+
+            new_layer_outputs.push(new_layer_output);
+        }
+
+        Ok(new_layer_outputs)
+    }
+
+    fn pool_layer(
+        &self,
+        token_offsets: &Tensor,
+        layer: &Tensor,
+    ) -> Result<Tensor, TransformerError> {
+        let (batch_size, _, hidden_size) = layer.size3()?;
+
+        // We want to retain the first piece as the root representation.
+        let root_index = Tensor::from(0)
+            .expand(&[batch_size, 1], false)
+            .f_to_device(token_offsets.device())?;
+
+        let token_offsets_with_root = Tensor::f_cat(&[&root_index, token_offsets], 1)?;
+
+        let pooled_layer = match self {
+            PiecePooler::Discard => layer.f_gather(
+                1,
+                &token_offsets_with_root
+                    .f_unsqueeze(-1)?
+                    .f_expand(&[-1, -1, hidden_size], false)?
+                    // -1 is used for padding, convert into valid index.
+                    .f_abs()?,
+                false,
+            )?,
+        };
+
+        Ok(pooled_layer)
+    }
+}

--- a/syntaxdot/testdata/sticker.conf
+++ b/syntaxdot/testdata/sticker.conf
@@ -15,6 +15,7 @@ encoders = [
 
 [model]
 parameters = "epoch-99"
+pooler = "discard"
 position_embeddings = "model"
 pretrain_config = "bert_config.json"
 pretrain_type = "bert"


### PR DESCRIPTION
This change adds a data type PiecePooler that is used by BertModel to
pool the pieces of a token after encoding of the input. This has
several benefits:
    
- Every layer after the pooler can assume that their input consists of
  token representations. This simplifies those layers, because they do
  not have to mask out non-initial pieces.
- It opens up the possibility to implement and experiment with
  different pooling functions.
    
Currently, only one pooler is available: PiecePooler::Discard. This
pooler uses the initial piece of a token as the token representation
and discards all continuation pieces. It results in the same
representations being used prior to this change and is therefore
compatible with existing SyntaxDot 0.3 models

With this change, it also became easy to implement label smoothing for
biaffine head targets, which is therefore done as well.
