### PR TITLE
Introduce TokenOffsets, TokenMask, and SequenceLength wrappers

### DIFF
--- a/syntaxdot-cli/src/subcommands/finetune.rs
+++ b/syntaxdot-cli/src/subcommands/finetune.rs
@@ -13,7 +13,6 @@ use syntaxdot::encoders::Encoders;
 use syntaxdot::lr::{ExponentialDecay, LearningRateSchedule, PlateauLearningRate};
 use syntaxdot::model::bert::{BertModel, FreezeLayers};
 use syntaxdot::optimizers::{GradScaler, Optimizer};
-use syntaxdot::util::seq_len_to_mask;
 use syntaxdot_encoders::dependency::ImmutableDependencyEncoder;
 use syntaxdot_tokenizers::Tokenize;
 use tch::nn::{self, AdamW};
@@ -288,9 +287,9 @@ impl FinetuneApp {
                 )
             };
 
-            let attention_mask = seq_len_to_mask(&batch.seq_lens, batch.inputs.size()[1])?;
+            let attention_mask = batch.seq_lens.attention_mask()?;
 
-            let n_batch_tokens = i64::from(batch.token_offsets.f_ne(-1)?.f_sum(Kind::Int64)?);
+            let n_batch_tokens = i64::from(batch.token_offsets.token_mask()?.f_sum(Kind::Int64)?);
 
             let model_loss = autocast_or_preserve(self.mixed_precision, || {
                 model.loss(

--- a/syntaxdot/src/model/pooling.rs
+++ b/syntaxdot/src/model/pooling.rs
@@ -4,6 +4,7 @@ use syntaxdot_transformers::TransformerError;
 use tch::Tensor;
 
 use crate::error::SyntaxDotError;
+use crate::tensor::TokenOffsets;
 
 /// Word/sentence piece pooler.
 ///
@@ -26,7 +27,7 @@ impl PiecePooler {
     /// Pool pieces in all layers.
     pub fn pool(
         &self,
-        token_offsets: &Tensor,
+        token_offsets: &TokenOffsets,
         layer_outputs: &[LayerOutput],
     ) -> Result<Vec<LayerOutput>, SyntaxDotError> {
         let mut new_layer_outputs = Vec::with_capacity(layer_outputs.len());
@@ -43,7 +44,7 @@ impl PiecePooler {
 
     fn pool_layer(
         &self,
-        token_offsets: &Tensor,
+        token_offsets: &TokenOffsets,
         layer: &Tensor,
     ) -> Result<Tensor, TransformerError> {
         let (batch_size, _, hidden_size) = layer.size3()?;

--- a/syntaxdot/src/model/seq_classifiers.rs
+++ b/syntaxdot/src/model/seq_classifiers.rs
@@ -12,6 +12,7 @@ use crate::config::PretrainConfig;
 use crate::encoders::Encoders;
 use crate::error::SyntaxDotError;
 use crate::model::bert::PretrainBertConfig;
+use crate::tensor::TokenMask;
 use std::time::Instant;
 
 /// A set of sequence classifiers.
@@ -102,7 +103,7 @@ impl SequenceClassifiers {
         layers: &[LayerOutput],
         targets: &HashMap<String, Tensor>,
         label_smoothing: Option<f64>,
-        token_mask: &Tensor,
+        token_mask: &TokenMask,
         train: bool,
     ) -> Result<SequenceClassifiersLoss, SyntaxDotError> {
         // Remove root token representation.

--- a/syntaxdot/src/tagger/mod.rs
+++ b/syntaxdot/src/tagger/mod.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use std::convert::TryInto;
 
 use ndarray::{s, Array1, ArrayD, Axis};
+use syntaxdot_encoders::dependency::ImmutableDependencyEncoder;
 use syntaxdot_encoders::{EncodingProb, SentenceDecoder};
 use syntaxdot_tokenizers::SentenceWithPieces;
 use tch::Device;
@@ -13,8 +14,6 @@ use crate::model::bert::BertModel;
 use crate::model::biaffine_dependency_layer::BiaffineScoreLogits;
 use crate::model::seq_classifiers::TopK;
 use crate::tensor::{TensorBuilder, Tensors};
-use crate::util::seq_len_to_mask;
-use syntaxdot_encoders::dependency::ImmutableDependencyEncoder;
 
 /// A sequence tagger.
 pub struct Tagger {
@@ -48,7 +47,7 @@ impl Tagger {
         let tensors = self.prepare_batch(sentences);
 
         // Get model predictions.
-        let attention_mask = seq_len_to_mask(&tensors.seq_lens, tensors.inputs.size()[1])?;
+        let attention_mask = tensors.seq_lens.attention_mask()?;
         let predictions = self.model.predict(
             &tensors.inputs.to_device(self.device),
             &attention_mask.to_device(self.device),

--- a/syntaxdot/src/util.rs
+++ b/syntaxdot/src/util.rs
@@ -1,7 +1,4 @@
 use rand::Rng;
-use tch::{Kind, Tensor};
-
-use crate::error::SyntaxDotError;
 
 pub struct RandomRemoveVec<T, R> {
     inner: Vec<T>,
@@ -60,20 +57,6 @@ where
         self.inner
             .swap_remove(self.rng.gen_range(0, self.inner.len()))
     }
-}
-
-/// Convert sequence lengths to masks.
-pub fn seq_len_to_mask(seq_lens: &Tensor, max_len: i64) -> Result<Tensor, SyntaxDotError> {
-    let batch_size = seq_lens.size()[0];
-    Ok(Tensor::f_arange(max_len, (Kind::Int, seq_lens.device()))?
-        // Construct a matrix [batch_size, max_len] where each row
-        // is 0..(max_len - 1).
-        .f_repeat(&[batch_size])?
-        .f_view_(&[batch_size, max_len])?
-        // Time steps less than the length in seq_lens are active.
-        .f_lt_1(&seq_lens.unsqueeze(1))?
-        // For some reason the kind is Int?
-        .to_kind(Kind::Bool))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
These types wrap Tensor and help to avoid confusion between passing
different types of tensors to methods. They also provide some
convenience methods to avoid ad-hoc conversions.