### PR TITLE
Add mean pooler for token representations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added support for biaffine dependency parsing (Dozat & Manning, 2016).
   Biaffine parsing is enabled through the `biaffine` configuration option.
+- Added support for pooling the pieces of a token by taking the mean
+  of the pieces. This type of pooling is enabled by setting the
+  `model.pooler` option to `mean`. The old behavior of discarding
+  continuation pieces is used when this option is set to `discard`.
 - Add the `keep-best` option to the `finetune` and `distill`
   subcommands. With this option only the parameter files for the N
   best epochs/steps are retained during distillation.

--- a/syntaxdot-cli/src/subcommands/finetune.rs
+++ b/syntaxdot-cli/src/subcommands/finetune.rs
@@ -289,13 +289,13 @@ impl FinetuneApp {
 
             let attention_mask = batch.seq_lens.attention_mask()?;
 
-            let n_batch_tokens = i64::from(batch.token_offsets.token_mask()?.f_sum(Kind::Int64)?);
+            let n_batch_tokens = i64::from(batch.token_spans.token_mask()?.f_sum(Kind::Int64)?);
 
             let model_loss = autocast_or_preserve(self.mixed_precision, || {
                 model.loss(
                     &batch.inputs.to_device(self.device),
                     &attention_mask.to_device(self.device),
-                    &batch.token_offsets.to_device(self.device),
+                    &batch.token_spans.to_device(self.device),
                     batch
                         .biaffine_encodings
                         .map(|tensors| tensors.to_device(self.device)),

--- a/syntaxdot/src/model/bert.rs
+++ b/syntaxdot/src/model/bert.rs
@@ -24,7 +24,7 @@ use crate::model::biaffine_dependency_layer::{
 };
 use crate::model::pooling::PiecePooler;
 use crate::model::seq_classifiers::{SequenceClassifiers, SequenceClassifiersLoss, TopK};
-use crate::tensor::{BiaffineTensors, TokenMask, TokenOffsets};
+use crate::tensor::{BiaffineTensors, TokenMask, TokenSpans};
 
 pub trait PretrainBertConfig {
     fn bert_config(&self) -> Cow<BertConfig>;
@@ -270,7 +270,7 @@ impl BertModel {
         &self,
         inputs: &Tensor,
         attention_mask: &Tensor,
-        token_offsets: &TokenOffsets,
+        token_spans: &TokenSpans,
         train: bool,
         freeze_layers: FreezeLayers,
     ) -> Result<Vec<LayerOutput>, SyntaxDotError> {
@@ -288,7 +288,7 @@ impl BertModel {
             self.encoder.encode(&embeds, Some(&attention_mask), train)?
         };
 
-        let mut pooled = self.pooler.pool(token_offsets, &encoded)?;
+        let mut pooled = self.pooler.pool(token_spans, &encoded)?;
 
         for layer in &mut pooled {
             *layer.output_mut() = if freeze_layers.classifiers {
@@ -321,11 +321,11 @@ impl BertModel {
         &self,
         inputs: &Tensor,
         attention_mask: &Tensor,
-        token_offsets: &TokenOffsets,
+        token_spans: &TokenSpans,
         train: bool,
         freeze_layers: FreezeLayers,
     ) -> Result<HashMap<String, Tensor>, SyntaxDotError> {
-        let encoding = self.encode(inputs, attention_mask, token_offsets, train, freeze_layers)?;
+        let encoding = self.encode(inputs, attention_mask, token_spans, train, freeze_layers)?;
         self.seq_classifiers.forward_t(&encoding, train)
     }
 
@@ -364,16 +364,16 @@ impl BertModel {
         &self,
         inputs: &Tensor,
         attention_mask: &Tensor,
-        token_offsets: &TokenOffsets,
+        token_spans: &TokenSpans,
         biaffine_tensors: Option<BiaffineTensors<Tensor>>,
         targets: &HashMap<String, Tensor>,
         label_smoothing: Option<f64>,
         train: bool,
         freeze_layers: FreezeLayers,
     ) -> Result<BertLoss, SyntaxDotError> {
-        let encoding = self.encode(inputs, attention_mask, token_offsets, train, freeze_layers)?;
+        let encoding = self.encode(inputs, attention_mask, token_spans, train, freeze_layers)?;
 
-        let token_mask = token_offsets.token_mask()?;
+        let token_mask = token_spans.token_mask()?;
 
         if freeze_layers.classifiers {
             tch::no_grad(|| {
@@ -444,12 +444,12 @@ impl BertModel {
         &self,
         inputs: &Tensor,
         attention_mask: &Tensor,
-        token_offsets: &TokenOffsets,
+        token_spans: &TokenSpans,
     ) -> Result<Predictions, SyntaxDotError> {
         let encoding = self.encode(
             inputs,
             attention_mask,
-            token_offsets,
+            token_spans,
             false,
             FreezeLayers {
                 embeddings: true,
@@ -461,7 +461,7 @@ impl BertModel {
         let biaffine_score_logits = self
             .biaffine
             .as_ref()
-            .map(|biaffine| biaffine.forward(&encoding, &token_offsets.token_mask()?, false, false))
+            .map(|biaffine| biaffine.forward(&encoding, &token_spans.token_mask()?, false, false))
             .transpose()?;
         let sequences_top_k = self.seq_classifiers.top_k(&encoding, 3)?;
 

--- a/syntaxdot/src/model/pooling.rs
+++ b/syntaxdot/src/model/pooling.rs
@@ -1,10 +1,10 @@
 use serde::{Deserialize, Serialize};
 use syntaxdot_transformers::models::LayerOutput;
 use syntaxdot_transformers::TransformerError;
-use tch::Tensor;
+use tch::{Kind, Tensor};
 
 use crate::error::SyntaxDotError;
-use crate::tensor::TokenOffsets;
+use crate::tensor::{TokenSpans, TokenSpansWithRoot};
 
 /// Word/sentence piece pooler.
 ///
@@ -21,19 +21,31 @@ use crate::tensor::TokenOffsets;
 pub enum PiecePooler {
     /// Discard continuation pieces.
     Discard,
+
+    /// Use the mean of the piece representations as token representations.
+    Mean,
 }
 
 impl PiecePooler {
     /// Pool pieces in all layers.
     pub fn pool(
         &self,
-        token_offsets: &TokenOffsets,
+        token_spans: &TokenSpans,
         layer_outputs: &[LayerOutput],
     ) -> Result<Vec<LayerOutput>, SyntaxDotError> {
         let mut new_layer_outputs = Vec::with_capacity(layer_outputs.len());
+
+        // Note: it would seem more efficient to stack all layers and pool all layers
+        // at the same time. However, this leads to significant memory overhead, given
+        // the shape [layers, batch_size, tokens_len, max_token_len, hidden], having
+        // one token consisting of many pieces blows up the memory use. We control the
+        // factor `layers` factor by pooling layer-wise.
+        //
+        // Todo: we could precompute the piece indices once and then only gather once
+        // per layer.
         for layer_output in layer_outputs {
             let new_layer_output = layer_output
-                .map_output(|output| self.pool_layer(token_offsets, output))
+                .map_output(|output| self.pool_layer(&token_spans.with_root()?, output))
                 .map_err(SyntaxDotError::BertError)?;
 
             new_layer_outputs.push(new_layer_output);
@@ -42,32 +54,192 @@ impl PiecePooler {
         Ok(new_layer_outputs)
     }
 
+    /// Pool the pieces in a single layer.
     fn pool_layer(
         &self,
-        token_offsets: &TokenOffsets,
+        token_spans: &TokenSpansWithRoot,
         layer: &Tensor,
     ) -> Result<Tensor, TransformerError> {
-        let (batch_size, _, hidden_size) = layer.size3()?;
-
-        // We want to retain the first piece as the root representation.
-        let root_index = Tensor::from(0)
-            .expand(&[batch_size, 1], false)
-            .f_to_device(token_offsets.device())?;
-
-        let token_offsets_with_root = Tensor::f_cat(&[&root_index, token_offsets], 1)?;
+        let token_embeddings = token_spans.embeddings_per_token(layer)?;
 
         let pooled_layer = match self {
-            PiecePooler::Discard => layer.f_gather(
-                1,
-                &token_offsets_with_root
-                    .f_unsqueeze(-1)?
-                    .f_expand(&[-1, -1, hidden_size], false)?
-                    // -1 is used for padding, convert into valid index.
-                    .f_abs()?,
-                false,
-            )?,
+            PiecePooler::Discard => Self::pool_discard(&token_embeddings)?,
+            PiecePooler::Mean => Self::pool_mean(&token_embeddings)?,
         };
 
         Ok(pooled_layer)
+    }
+
+    /// Discard pooling.
+    fn pool_discard(token_embeddings: &TokenEmbeddings) -> Result<Tensor, TransformerError> {
+        Ok(token_embeddings
+            .embeddings
+            .f_slice(2, 0, 1, 1)?
+            .f_squeeze1(2)?)
+    }
+
+    /// Mean pooling
+    fn pool_mean(token_embeddings: &TokenEmbeddings) -> Result<Tensor, TransformerError> {
+        let pieces_per_token = token_embeddings
+            .mask
+            .f_sum1(&[2], false, Kind::Float)?
+            .f_clamp_min(1)?;
+        Ok(token_embeddings
+            .embeddings
+            .f_sum1(&[2], false, Kind::Float)?
+            .f_div(&pieces_per_token.f_unsqueeze(-1)?)?)
+    }
+}
+
+#[derive(Debug)]
+struct TokenEmbeddings {
+    embeddings: Tensor,
+    mask: Tensor,
+}
+
+/// Piece embeddings per token.
+trait EmbeddingsPerToken {
+    /// Get the piece embeddings for each token.
+    ///
+    /// This method takes a batch of piece embeddings and partitions the
+    /// embeddings per token.
+    ///
+    /// The input of this method is a batch of pieces with the shape
+    /// `[batch_size, pieces_len, hidden_size]` and partitions the pieces
+    /// by token with shape `[batch_size, tokens_len, max_token_len, hidden_size]`,
+    /// where `max_token_len` is the maximum length of a token in pieces. For
+    /// tokens that are shorter than the maximum length, the remaining padding
+    /// can be discarded with the mask of shape
+    /// `[batch_size, tokens_len, max_token_len]`.
+    fn embeddings_per_token(
+        &self,
+        embeddings: &Tensor,
+    ) -> Result<TokenEmbeddings, TransformerError>;
+}
+
+impl EmbeddingsPerToken for TokenSpansWithRoot {
+    fn embeddings_per_token(
+        &self,
+        embeddings: &Tensor,
+    ) -> Result<TokenEmbeddings, TransformerError> {
+        let (batch_size, _pieces_len, embed_size) = embeddings.size3()?;
+        let (_batch_size, tokens_len) = self.offsets().size2()?;
+
+        let max_token_len = i64::from(self.lens().max());
+
+        let piece_range = Tensor::f_arange(max_token_len, (Kind::Int64, self.lens().device()))?
+            .f_view([1, 1, max_token_len])?;
+
+        let mask = piece_range.less1(&self.lens().f_unsqueeze(-1)?);
+
+        let piece_indices = (piece_range + self.offsets().unsqueeze(-1)).f_mul(&mask)?;
+
+        let piece_embeddings = embeddings
+            .f_gather(
+                1,
+                &piece_indices
+                    .f_view([batch_size, -1, 1])?
+                    .f_expand(&[-1, -1, embed_size], true)?,
+                false,
+            )?
+            .f_view([batch_size, tokens_len, max_token_len, embed_size])?
+            .f_mul(&mask.f_unsqueeze(-1)?)?;
+
+        Ok(TokenEmbeddings {
+            embeddings: piece_embeddings,
+            mask,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tch::{Device, Kind, Tensor};
+
+    use crate::model::pooling::{EmbeddingsPerToken, PiecePooler};
+    use crate::tensor::{TokenSpans, TokenSpansWithRoot};
+
+    #[test]
+    fn discard_pooler_works_correctly() {
+        let spans = TokenSpans::new(
+            Tensor::of_slice2(&[[1, 3, 4, -1, -1], [1, 3, 4, 6, 7]]),
+            Tensor::of_slice2(&[[2, 1, 1, -1, -1], [2, 1, 2, 1, 1]]),
+        );
+
+        let hidden = Tensor::arange2(36, 0, -1, (Kind::Int64, Device::Cpu))
+            .view([2, 9, 2])
+            .to_kind(Kind::Float);
+
+        let pooler = PiecePooler::Discard;
+
+        let token_embeddings = pooler
+            .pool_layer(&spans.with_root().unwrap(), &hidden)
+            .unwrap();
+
+        assert_eq!(
+            token_embeddings,
+            Tensor::of_slice2(&[
+                &[36, 35, 34, 33, 30, 29, 28, 27, 0, 0, 0, 0],
+                &[18, 17, 16, 15, 12, 11, 10, 9, 6, 5, 4, 3]
+            ])
+            .view([2, 6, 2])
+        );
+    }
+
+    #[test]
+    fn embeddings_are_returned_per_token() {
+        let spans = TokenSpansWithRoot::new(
+            Tensor::of_slice2(&[[1, 3, 4, -1, -1], [1, 3, 4, 6, 7]]),
+            Tensor::of_slice2(&[[2, 1, 1, -1, -1], [2, 1, 2, 1, 1]]),
+        );
+
+        let hidden = Tensor::arange2(32, 0, -1, (Kind::Int64, Device::Cpu)).view([2, 8, 2]);
+
+        let token_embeddings = spans.embeddings_per_token(&hidden).unwrap();
+
+        assert_eq!(
+            token_embeddings.embeddings,
+            Tensor::of_slice(&[
+                30, 29, 28, 27, 26, 25, 0, 0, 24, 23, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 14, 13, 12, 11,
+                10, 9, 0, 0, 8, 7, 6, 5, 4, 3, 0, 0, 2, 1, 0, 0
+            ])
+            .view([2, 5, 2, 2])
+        );
+
+        assert_eq!(
+            token_embeddings.mask,
+            Tensor::of_slice(&[
+                true, true, true, false, true, false, false, false, false, false, true, true, true,
+                false, true, true, true, false, true, false
+            ])
+            .view([2, 5, 2])
+        );
+    }
+
+    #[test]
+    fn mean_pooler_works_correctly() {
+        let spans = TokenSpans::new(
+            Tensor::of_slice2(&[[1, 3, 4, -1, -1], [1, 3, 4, 6, 7]]),
+            Tensor::of_slice2(&[[2, 1, 1, -1, -1], [2, 1, 2, 1, 1]]),
+        );
+
+        let hidden = Tensor::arange2(36, 0, -1, (Kind::Int64, Device::Cpu))
+            .view([2, 9, 2])
+            .to_kind(Kind::Float);
+
+        let pooler = PiecePooler::Mean;
+
+        let token_embeddings = pooler
+            .pool_layer(&spans.with_root().unwrap(), &hidden)
+            .unwrap();
+
+        assert_eq!(
+            token_embeddings,
+            Tensor::of_slice2(&[
+                &[36, 35, 33, 32, 30, 29, 28, 27, 0, 0, 0, 0,],
+                &[18, 17, 15, 14, 12, 11, 9, 8, 6, 5, 4, 3]
+            ])
+            .view([2, 6, 2])
+        );
     }
 }


### PR DESCRIPTION
This pooler takes the mean of all the representations of the pieces in
a token as the token's representation.
