### PR TITLE
distill: add support for hidden layer loss

### DIFF
--- a/syntaxdot-cli/src/io.rs
+++ b/syntaxdot-cli/src/io.rs
@@ -15,6 +15,7 @@ pub struct Model {
     pub biaffine_encoder: Option<ImmutableDependencyEncoder>,
     pub encoders: Encoders,
     pub model: BertModel,
+    pub pretrain_config: PretrainConfig,
     pub tokenizer: Box<dyn Tokenize>,
     pub vs: VarStore,
 }
@@ -117,6 +118,7 @@ impl Model {
             biaffine_encoder: biaffine_decoder,
             encoders,
             model,
+            pretrain_config,
             tokenizer,
             vs,
         })


### PR DESCRIPTION
By default, the student model uses the teacher's softmaxes for
training. The distill subcommand already provided the option to use
attention loss as an additional loss. However, attention loss only
works when the student and the teacher have the same tokenization
and number of layers.

This change adds an additional optional loss, that computes the mean
squared error of the teacher's and the student's hidden states. A
linear transformation is learned for mapping the student's space to
the teacher's space, which is particularly useful if the student and
the teacher use different dimensionalities. Additionally, a layer
mapping is specified to handle the case where the number of teacher
and student layers differ. For example,

```
--hidden-loss 0:0,2:1,4:2,6:3,8:4,10:5,12:6
```

Maps layers 0 (embedding), 2, 4, 6, 8, 10, and 12 of the teacher to
layers 0, 1, 2, 3, 4, 5, 6 of the student.

This type of loss was inspired by TinyBERT (Jiao et al., 2020).