### PR TITLE
nix: fix syntaxdotWithCuda build, switch to nixpkgs-unstable

### DIFF
--- a/build-support/crate-overrides.nix
+++ b/build-support/crate-overrides.nix
@@ -5,7 +5,6 @@
 # Native build inputs
 , cmake
 , installShellFiles
-, removeReferencesTo
 
 # Build inputs
 , hdf5
@@ -29,11 +28,8 @@ defaultCrateOverrides // {
     pname = "syntaxdot";
     name = "${pname}-${attr.version}";
 
-    buildInputs = [ libtorch-bin ];
-
     nativeBuildInputs = [
       installShellFiles
-      removeReferencesTo
     ];
 
     postInstall = ''
@@ -47,11 +43,7 @@ defaultCrateOverrides // {
       done
 
       installShellCompletion completions.{bash,fish,zsh}
-
-      remove-references-to -t ${libtorch-bin.dev} $out/bin/syntaxdot
     '';
-
-    disallowedReferences = [ libtorch-bin.dev ];
 
     meta = with lib; {
       description = "Neural sequence labeler";
@@ -62,6 +54,9 @@ defaultCrateOverrides // {
   };
 
   torch-sys = attr: {
-    LIBTORCH = libtorch-bin.dev;
+    LIBTORCH = symlinkJoin {
+      name = "torch-join";
+      paths = [ libtorch-bin.dev libtorch-bin.out ];
+    };
   };
 }

--- a/flake.lock
+++ b/flake.lock
@@ -18,15 +18,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1615308962,
-        "narHash": "sha256-jBQUmb5aNfTNlFFV6TaQPySYnJhARV7TC5miBTn2FFs=",
+        "lastModified": 1616084726,
+        "narHash": "sha256-WEYz+MoWkSgf6vwsD0z3nsOuIftJMYG6hDNjTdD56PQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8d327040c03fe8afbc2a2a9973af17b0d1a77bf4",
+        "rev": "fcab19deb78fbb5ea24e19b133cf34358176396a",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,6 @@
         config = {
           allowUnfreePredicate = pkg: builtins.elem (pkgsWithCuda.lib.getName pkg) [
             "libtorch"
-            "nvidia-x11"
           ];
           cudaSupport = true;
         };
@@ -60,8 +59,9 @@
         };
       });
 
-      packages.syntaxdot = syntaxdot pkgsWithoutCuda;
-
-      packages.syntaxdotWithCuda = syntaxdot pkgsWithCuda;
+      packages = {
+        syntaxdot = syntaxdot pkgsWithoutCuda;
+        syntaxdotWithCuda = syntaxdot pkgsWithCuda;
+      };
     });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "SyntaxDot sequence labeler";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     crate2nix = {
       url = "github:kolloch/crate2nix";
       flake = false;


### PR DESCRIPTION
* Fix linkage in the `syntaxdotWithCuda` package.
* Switch back to the `nixpkg-unstable` channel, now that it has
  libtorch 1.8.0.
