### PR TITLE
Apply biaffine decoding before sequence labeling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Apply biaffine dependency encoding before sequence labeling, so that
+  the TüBa-D/Z lemma decoder has access to dependency relations.
+
 ## 0.3.0
 
 ### Added

--- a/syntaxdot-encoders/src/depseq/error.rs
+++ b/syntaxdot-encoders/src/depseq/error.rs
@@ -11,7 +11,7 @@ pub enum EncodeError {
     MissingHead { token: usize, sent: Vec<String> },
 
     /// The token's head does not have a part-of-speech.
-    MissingPOS { sent: Vec<String>, token: usize },
+    MissingPos { sent: Vec<String>, token: usize },
 
     /// The token does not have a dependency relation.
     MissingRelation { token: usize, sent: Vec<String> },
@@ -34,7 +34,7 @@ impl EncodeError {
     /// Construct an error. `token` is the node index for which the
     /// error applies in `sentence`.
     pub fn missing_pos(token: usize, sentence: &Sentence) -> EncodeError {
-        EncodeError::MissingPOS {
+        EncodeError::MissingPos {
             sent: Self::sentence_to_forms(sentence),
             token: token - 1,
         }
@@ -79,7 +79,7 @@ impl fmt::Display for EncodeError {
                 "Token does not have a head:\n\n{}\n",
                 Self::format_bracketed(*token, sent),
             ),
-            MissingPOS { token, sent } => write!(
+            MissingPos { token, sent } => write!(
                 f,
                 "Head of token '{}' does not have a part-of-speech:\n\n{}\n",
                 sent[*token],
@@ -103,5 +103,5 @@ pub(crate) enum DecodeError {
 
     /// The head part-of-speech tag does not occur in the sentence.
     #[error("unknown part-of-speech tag")]
-    InvalidPOS,
+    InvalidPos,
 }

--- a/syntaxdot-encoders/src/depseq/mod.rs
+++ b/syntaxdot-encoders/src/depseq/mod.rs
@@ -49,7 +49,7 @@ mod tests {
     use conllu::io::Reader;
     use udgraph::graph::{Node, Sentence};
 
-    use super::{POSLayer, RelativePOSEncoder, RelativePositionEncoder};
+    use super::{PosLayer, RelativePosEncoder, RelativePositionEncoder};
     use crate::{EncodingProb, SentenceDecoder, SentenceEncoder};
 
     const NON_PROJECTIVE_DATA: &str = "testdata/lassy-small-dev.conllu";
@@ -100,7 +100,7 @@ mod tests {
 
     #[test]
     fn relative_pos_position() {
-        let encoder = RelativePOSEncoder::new(POSLayer::XPos, ROOT_RELATION);
+        let encoder = RelativePosEncoder::new(PosLayer::XPos, ROOT_RELATION);
         test_encoding(NON_PROJECTIVE_DATA, encoder);
     }
 

--- a/syntaxdot-encoders/src/depseq/post_processing.rs
+++ b/syntaxdot-encoders/src/depseq/post_processing.rs
@@ -181,7 +181,7 @@ mod tests {
     use udgraph::token::TokenBuilder;
 
     use super::{attach_orphans, break_cycles, find_or_create_root, first_root};
-    use crate::depseq::{DependencyEncoding, POSLayer, RelativePOS, RelativePOSEncoder};
+    use crate::depseq::{DependencyEncoding, PosLayer, RelativePos, RelativePosEncoder};
     use crate::{EncodingProb, SentenceEncoder};
 
     const ROOT_POS: &str = "ROOT";
@@ -259,7 +259,7 @@ mod tests {
         sent.dep_graph_mut()
             .add_deprel(DepTriple::new(0, Some(ROOT_RELATION), 3));
 
-        let encodings: Vec<_> = RelativePOSEncoder::new(POSLayer::XPos, ROOT_RELATION)
+        let encodings: Vec<_> = RelativePosEncoder::new(PosLayer::XPos, ROOT_RELATION)
             .encode(&test_graph())
             .unwrap()
             .into_iter()
@@ -275,11 +275,11 @@ mod tests {
     fn add_missing_root() {
         let mut sent = test_graph_no_root();
 
-        let encodings: Vec<Vec<EncodingProb<DependencyEncoding<RelativePOS>>>> = vec![
+        let encodings: Vec<Vec<EncodingProb<DependencyEncoding<RelativePos>>>> = vec![
             vec![EncodingProb::new(
                 DependencyEncoding {
                     label: ROOT_RELATION.to_owned(),
-                    head: RelativePOS::new(ROOT_POS, -1),
+                    head: RelativePos::new(ROOT_POS, -1),
                 },
                 0.4,
             )],
@@ -288,14 +288,14 @@ mod tests {
                 EncodingProb::new(
                     DependencyEncoding {
                         label: "distractor".to_owned(),
-                        head: RelativePOS::new(ROOT_POS, -1),
+                        head: RelativePos::new(ROOT_POS, -1),
                     },
                     0.6,
                 ),
                 EncodingProb::new(
                     DependencyEncoding {
                         label: ROOT_RELATION.to_owned(),
-                        head: RelativePOS::new(ROOT_POS, -1),
+                        head: RelativePos::new(ROOT_POS, -1),
                     },
                     0.4,
                 ),
@@ -303,17 +303,17 @@ mod tests {
             vec![EncodingProb::new(
                 DependencyEncoding {
                     label: ROOT_RELATION.to_owned(),
-                    head: RelativePOS::new(ROOT_POS, -1),
+                    head: RelativePos::new(ROOT_POS, -1),
                 },
                 0.3,
             )],
         ];
 
-        let pos_table = RelativePOSEncoder::new(POSLayer::XPos, "root").pos_position_table(&sent);
+        let pos_table = RelativePosEncoder::new(PosLayer::XPos, "root").pos_position_table(&sent);
         find_or_create_root(
             &encodings,
             &mut sent,
-            |idx, encoding| RelativePOSEncoder::decode_idx(&pos_table, idx, encoding).ok(),
+            |idx, encoding| RelativePosEncoder::decode_idx(&pos_table, idx, encoding).ok(),
             ROOT_RELATION,
         );
 

--- a/syntaxdot-encoders/src/lemma/edit_tree.rs
+++ b/syntaxdot-encoders/src/lemma/edit_tree.rs
@@ -99,36 +99,36 @@ impl EditTree {
 
 /// Struct representing a continuous match between two sequences.
 #[derive(Debug, PartialEq, Eq, Hash)]
-struct LCSMatch {
+struct LcsMatch {
     start_src: usize,
     start_targ: usize,
     length: usize,
 }
 
-impl LCSMatch {
+impl LcsMatch {
     fn new(start_src: usize, start_targ: usize, length: usize) -> Self {
-        LCSMatch {
+        LcsMatch {
             start_src,
             start_targ,
             length,
         }
     }
     fn empty() -> Self {
-        LCSMatch::new(0, 0, 0)
+        LcsMatch::new(0, 0, 0)
     }
 }
 
-impl PartialOrd for LCSMatch {
-    fn partial_cmp(&self, other: &LCSMatch) -> Option<Ordering> {
+impl PartialOrd for LcsMatch {
+    fn partial_cmp(&self, other: &LcsMatch) -> Option<Ordering> {
         Some(self.length.cmp(&other.length))
     }
 }
 
 /// Returns the start and end index of the longest match. Returns none if no match is found.
-fn longest_match(script: &[IndexedOperation<LCSOp>]) -> Option<LCSMatch> {
-    let mut longest = LCSMatch::empty();
+fn longest_match(script: &[IndexedOperation<LCSOp>]) -> Option<LcsMatch> {
+    let mut longest = LcsMatch::empty();
 
-    let mut script_slice = &script[..];
+    let mut script_slice = script;
     while !script_slice.is_empty() {
         let op = &script_slice[0];
 
@@ -144,7 +144,7 @@ fn longest_match(script: &[IndexedOperation<LCSOp>]) -> Option<LCSMatch> {
                     None => script_slice.len(),
                 };
                 if end > longest.length {
-                    longest = LCSMatch::new(in_start, o_start, end);
+                    longest = LcsMatch::new(in_start, o_start, end);
                 };
 
                 script_slice = &script_slice[end..];

--- a/syntaxdot-summary/src/event_writer.rs
+++ b/syntaxdot-summary/src/event_writer.rs
@@ -3,11 +3,11 @@ use std::io::{self, Write};
 use prost::Message;
 
 use crate::event_writer::event::What;
-use crate::record_writer::TFRecordWriter;
+use crate::record_writer::TfRecordWriter;
 use std::time::SystemTime;
 
 pub struct EventWriter<W> {
-    writer: TFRecordWriter<W>,
+    writer: TfRecordWriter<W>,
 }
 
 impl<W> EventWriter<W> {
@@ -30,7 +30,7 @@ where
 
     pub fn new_with_wall_time(write: W, wall_time: f64) -> io::Result<Self> {
         let mut writer = EventWriter {
-            writer: TFRecordWriter::from(write),
+            writer: TfRecordWriter::from(write),
         };
 
         writer.write_event_with_wall_time(

--- a/syntaxdot-summary/src/record_writer.rs
+++ b/syntaxdot-summary/src/record_writer.rs
@@ -3,24 +3,24 @@ use std::io::{self, Write};
 use crate::crc32::CheckSummer;
 
 /// Write data in TFRecord format.
-pub struct TFRecordWriter<W> {
+pub struct TfRecordWriter<W> {
     checksummer: CheckSummer,
     write: W,
 }
 
-impl<W> From<W> for TFRecordWriter<W>
+impl<W> From<W> for TfRecordWriter<W>
 where
     W: Write,
 {
     fn from(write: W) -> Self {
-        TFRecordWriter {
+        TfRecordWriter {
             checksummer: CheckSummer::new(),
             write,
         }
     }
 }
 
-impl<W> TFRecordWriter<W>
+impl<W> TfRecordWriter<W>
 where
     W: Write,
 {

--- a/syntaxdot-transformers/src/activations.rs
+++ b/syntaxdot-transformers/src/activations.rs
@@ -15,9 +15,9 @@ pub trait Activation: Clone + FallibleModule {}
 ///
 /// where Φ(x) is the CDF for the Gaussian distribution.
 #[derive(Clone, Copy, Debug)]
-pub struct GELUNew;
+pub struct GeluNew;
 
-impl FallibleModule for GELUNew {
+impl FallibleModule for GeluNew {
     type Error = TransformerError;
 
     fn forward(&self, input: &Tensor) -> Result<Tensor, Self::Error> {
@@ -30,7 +30,7 @@ impl FallibleModule for GELUNew {
     }
 }
 
-impl Activation for GELUNew {}
+impl Activation for GeluNew {}
 
 /// GELU activation function.
 ///
@@ -38,9 +38,9 @@ impl Activation for GELUNew {}
 ///
 /// where Φ(x) is the CDF for the Gaussian distribution.
 #[derive(Clone, Copy, Debug)]
-pub struct GELU;
+pub struct Gelu;
 
-impl FallibleModule for GELU {
+impl FallibleModule for Gelu {
     type Error = TransformerError;
 
     fn forward(&self, input: &Tensor) -> Result<Tensor, Self::Error> {
@@ -48,7 +48,7 @@ impl FallibleModule for GELU {
     }
 }
 
-impl Activation for GELU {}
+impl Activation for Gelu {}
 
 #[cfg(test)]
 mod tests {
@@ -58,12 +58,12 @@ mod tests {
     use ndarray::{array, ArrayD};
     use tch::Tensor;
 
-    use super::GELUNew;
+    use super::GeluNew;
     use crate::module::FallibleModule;
 
     #[test]
     fn gelu_new_returns_correct_values() {
-        let gelu_new = GELUNew;
+        let gelu_new = GeluNew;
         let activations: ArrayD<f32> = (&gelu_new
             .forward(&Tensor::of_slice(&[-1., -0.5, 0., 0.5, 1.]))
             .unwrap())

--- a/syntaxdot-transformers/src/models/bert/layer.rs
+++ b/syntaxdot-transformers/src/models/bert/layer.rs
@@ -340,8 +340,8 @@ pub(crate) fn bert_activations(
     activation_name: &str,
 ) -> Option<Box<dyn FallibleModule<Error = TransformerError>>> {
     match activation_name {
-        "gelu" => Some(Box::new(activations::GELU)),
-        "gelu_new" => Some(Box::new(activations::GELUNew)),
+        "gelu" => Some(Box::new(activations::Gelu)),
+        "gelu_new" => Some(Box::new(activations::GeluNew)),
         _ => None,
     }
 }

--- a/syntaxdot/src/config.rs
+++ b/syntaxdot/src/config.rs
@@ -320,7 +320,7 @@ fn relativize_path(config_path: &Path, filename: &str) -> Result<String, SyntaxD
 
 #[cfg(test)]
 mod tests {
-    use syntaxdot_encoders::depseq::POSLayer;
+    use syntaxdot_encoders::depseq::PosLayer;
     use syntaxdot_encoders::layer::Layer;
     use syntaxdot_encoders::lemma::BackoffStrategy;
 
@@ -363,7 +363,7 @@ mod tests {
                         NamedEncoderConfig {
                             name: "dep".to_string(),
                             encoder: EncoderType::Dependency {
-                                encoder: DependencyEncoder::RelativePOS(POSLayer::XPos),
+                                encoder: DependencyEncoder::RelativePos(PosLayer::XPos),
                                 root_relation: "root".to_string()
                             }
                         },

--- a/syntaxdot/src/dataset/conll.rs
+++ b/syntaxdot/src/dataset/conll.rs
@@ -52,7 +52,7 @@ where
     fn next(&mut self) -> Option<Self::Item> {
         self.sentences.next().map(|s| {
             s.map(|s| self.tokenizer.tokenize(s))
-                .map_err(SyntaxDotError::ConlluIOError)
+                .map_err(SyntaxDotError::ConlluIoError)
         })
     }
 }

--- a/syntaxdot/src/dataset/plaintext.rs
+++ b/syntaxdot/src/dataset/plaintext.rs
@@ -50,7 +50,7 @@ where
             // Bubble up read errors.
             let line = match line {
                 Ok(line) => line,
-                Err(err) => return Some(Err(SyntaxDotError::IOError(err))),
+                Err(err) => return Some(Err(SyntaxDotError::IoError(err))),
             };
 
             let line_trimmed = line.trim();

--- a/syntaxdot/src/encoders/config.rs
+++ b/syntaxdot/src/encoders/config.rs
@@ -1,7 +1,7 @@
 use std::ops::Deref;
 
 use serde::{Deserialize, Serialize};
-use syntaxdot_encoders::depseq::POSLayer;
+use syntaxdot_encoders::depseq::PosLayer;
 use syntaxdot_encoders::layer::Layer;
 use syntaxdot_encoders::lemma::BackoffStrategy;
 
@@ -50,7 +50,7 @@ pub enum DependencyEncoder {
     RelativePosition,
 
     /// Encode a token's head by relative position of the POS tag.
-    RelativePOS(POSLayer),
+    RelativePos(PosLayer),
 }
 
 /// Configuration of an encoder with a name.

--- a/syntaxdot/src/encoders/encoders.rs
+++ b/syntaxdot/src/encoders/encoders.rs
@@ -5,7 +5,7 @@ use numberer::Numberer;
 use serde::{Deserialize, Serialize};
 use syntaxdot_encoders::categorical::{ImmutableCategoricalEncoder, MutableCategoricalEncoder};
 use syntaxdot_encoders::depseq::{
-    DependencyEncoding, RelativePOS, RelativePOSEncoder, RelativePosition, RelativePositionEncoder,
+    DependencyEncoding, RelativePos, RelativePosEncoder, RelativePosition, RelativePositionEncoder,
 };
 use syntaxdot_encoders::layer::LayerEncoder;
 use syntaxdot_encoders::lemma::{EditTree, EditTreeEncoder, TdzLemmaEncoder};
@@ -93,7 +93,7 @@ pub enum DecoderError {
     Layer(<LayerEncoder as SentenceDecoder>::Error),
 
     #[error(transparent)]
-    RelativePOS(<RelativePOSEncoder as SentenceDecoder>::Error),
+    RelativePos(<RelativePosEncoder as SentenceDecoder>::Error),
 
     #[error(transparent)]
     RelativePosition(<RelativePositionEncoder as SentenceDecoder>::Error),
@@ -112,7 +112,7 @@ pub enum EncoderError {
     Layer(<LayerEncoder as SentenceEncoder>::Error),
 
     #[error(transparent)]
-    RelativePOS(<RelativePOSEncoder as SentenceEncoder>::Error),
+    RelativePos(<RelativePosEncoder as SentenceEncoder>::Error),
 
     #[error(transparent)]
     RelativePosition(<RelativePositionEncoder as SentenceEncoder>::Error),
@@ -126,7 +126,7 @@ pub enum EncoderError {
 pub enum Encoder {
     Lemma(CategoricalEncoderWrap<EditTreeEncoder, EditTree>),
     Layer(CategoricalEncoderWrap<LayerEncoder, String>),
-    RelativePOS(CategoricalEncoderWrap<RelativePOSEncoder, DependencyEncoding<RelativePOS>>),
+    RelativePos(CategoricalEncoderWrap<RelativePosEncoder, DependencyEncoding<RelativePos>>),
     RelativePosition(
         CategoricalEncoderWrap<RelativePositionEncoder, DependencyEncoding<RelativePosition>>,
     ),
@@ -139,7 +139,7 @@ impl Encoder {
         match self {
             Encoder::Layer(encoder) => encoder.len(),
             Encoder::Lemma(encoder) => encoder.len(),
-            Encoder::RelativePOS(encoder) => encoder.len(),
+            Encoder::RelativePos(encoder) => encoder.len(),
             Encoder::RelativePosition(encoder) => encoder.len(),
             Encoder::TdzLemma(encoder) => encoder.len(),
         }
@@ -162,9 +162,9 @@ impl SentenceDecoder for Encoder {
             Encoder::Lemma(decoder) => decoder
                 .decode(labels, sentence)
                 .map_err(DecoderError::Lemma),
-            Encoder::RelativePOS(decoder) => decoder
+            Encoder::RelativePos(decoder) => decoder
                 .decode(labels, sentence)
-                .map_err(DecoderError::RelativePOS),
+                .map_err(DecoderError::RelativePos),
             Encoder::RelativePosition(decoder) => decoder
                 .decode(labels, sentence)
                 .map_err(DecoderError::RelativePosition),
@@ -184,8 +184,8 @@ impl SentenceEncoder for Encoder {
         match self {
             Encoder::Layer(encoder) => encoder.encode(sentence).map_err(EncoderError::Layer),
             Encoder::Lemma(encoder) => encoder.encode(sentence).map_err(EncoderError::Lemma),
-            Encoder::RelativePOS(encoder) => {
-                encoder.encode(sentence).map_err(EncoderError::RelativePOS)
+            Encoder::RelativePos(encoder) => {
+                encoder.encode(sentence).map_err(EncoderError::RelativePos)
             }
             Encoder::RelativePosition(encoder) => encoder
                 .encode(sentence)
@@ -200,11 +200,11 @@ impl From<&EncoderType> for Encoder {
         // We start labeling at 2. 0 is reserved for padding, 1 for continuations.
         match encoder_type {
             EncoderType::Dependency {
-                encoder: DependencyEncoder::RelativePOS(pos_layer),
+                encoder: DependencyEncoder::RelativePos(pos_layer),
                 root_relation,
-            } => Encoder::RelativePOS(
+            } => Encoder::RelativePos(
                 MutableCategoricalEncoder::new(
-                    RelativePOSEncoder::new(*pos_layer, root_relation),
+                    RelativePosEncoder::new(*pos_layer, root_relation),
                     Numberer::new(2),
                 )
                 .into(),

--- a/syntaxdot/src/error.rs
+++ b/syntaxdot/src/error.rs
@@ -16,7 +16,7 @@ pub enum SyntaxDotError {
     BertError(#[from] TransformerError),
 
     #[error(transparent)]
-    ConlluIOError(#[from] conllu::IOError),
+    ConlluIoError(#[from] conllu::IOError),
 
     #[error(transparent)]
     DecoderError(#[from] DecoderError),
@@ -31,7 +31,7 @@ pub enum SyntaxDotError {
     IllegalConfigurationError(String),
 
     #[error(transparent)]
-    IOError(#[from] io::Error),
+    IoError(#[from] io::Error),
 
     #[error("The optimizer does not have any associated trainable variables")]
     NoTrainableVariables,
@@ -49,7 +49,7 @@ pub enum SyntaxDotError {
     Tch(#[from] TchError),
 
     #[error(transparent)]
-    TOMLDeserializationError(#[from] toml::de::Error),
+    TomlDeserializationError(#[from] toml::de::Error),
 
     #[error(transparent)]
     TokenizerError(#[from] TokenizerError),

--- a/syntaxdot/src/tagger/mod.rs
+++ b/syntaxdot/src/tagger/mod.rs
@@ -62,14 +62,17 @@ impl Tagger {
             predictions.biaffine_score_logits.is_some(),
         );
 
-        self.decode_sequence_labels(sentences, predictions.sequences_top_k)?;
-
+        // Decode dependencies before sequence labels. Biaffine parsing does not require any
+        // other annotations. Sequence labelers, however, may require dependencies (e.g. the
+        // TüBa-D/Z lemmatizer).
         if let (Some(encoder), Some(biaffine_score_logits)) = (
             self.biaffine_encoder.as_ref(),
             predictions.biaffine_score_logits,
         ) {
             tch::no_grad(|| self.decode_biaffine(encoder, sentences, biaffine_score_logits))?
         }
+
+        self.decode_sequence_labels(sentences, predictions.sequences_top_k)?;
 
         Ok(())
     }


### PR DESCRIPTION
This ensures that sequence label decoders such as TdzLemma have access
to dependency labels.
