### PR TITLE
Apply biaffine decoding before sequence labeling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Apply biaffine dependency encoding before sequence labeling, so that
+  the TüBa-D/Z lemma decoder has access to dependency relations.
+
 ## 0.3.0
 
 ### Added

--- a/syntaxdot-encoders/src/depseq/error.rs
+++ b/syntaxdot-encoders/src/depseq/error.rs
@@ -11,6 +11,7 @@ pub enum EncodeError {
     MissingHead { token: usize, sent: Vec<String> },
 
     /// The token's head does not have a part-of-speech.
+    #[allow(clippy::upper_case_acronyms)]
     MissingPOS { sent: Vec<String>, token: usize },
 
     /// The token does not have a dependency relation.
@@ -102,6 +103,7 @@ pub(crate) enum DecodeError {
     PositionOutOfBounds,
 
     /// The head part-of-speech tag does not occur in the sentence.
+    #[allow(clippy::upper_case_acronyms)]
     #[error("unknown part-of-speech tag")]
     InvalidPOS,
 }

--- a/syntaxdot-encoders/src/depseq/relative_pos.rs
+++ b/syntaxdot-encoders/src/depseq/relative_pos.rs
@@ -22,6 +22,7 @@ use crate::{EncodingProb, SentenceDecoder, SentenceEncoder};
 const ROOT_POS: &str = "ROOT";
 
 /// Part-of-speech layer.
+#[allow(clippy::upper_case_acronyms)]
 #[serde(rename_all = "lowercase")]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum POSLayer {
@@ -47,6 +48,7 @@ impl POSLayer {
 /// in terms of part-of-speech tags. For example, a position of
 /// *-2* with the pos *noun* means that the head is the second
 /// preceding noun.
+#[allow(clippy::upper_case_acronyms)]
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct RelativePOS {
     pos: String,
@@ -74,6 +76,7 @@ impl ToString for DependencyEncoding<RelativePOS> {
 /// This encoder encodes dependency relations as token labels. The
 /// dependency relation is encoded as-is. The position of the head
 /// is encoded relative to the (dependent) token by part-of-speech.
+#[allow(clippy::upper_case_acronyms)]
 #[derive(Clone, Deserialize, Eq, PartialEq, Serialize)]
 pub struct RelativePOSEncoder {
     pos_layer: POSLayer,

--- a/syntaxdot-encoders/src/lemma/edit_tree.rs
+++ b/syntaxdot-encoders/src/lemma/edit_tree.rs
@@ -98,6 +98,7 @@ impl EditTree {
 }
 
 /// Struct representing a continuous match between two sequences.
+#[allow(clippy::upper_case_acronyms)]
 #[derive(Debug, PartialEq, Eq, Hash)]
 struct LCSMatch {
     start_src: usize,
@@ -128,7 +129,7 @@ impl PartialOrd for LCSMatch {
 fn longest_match(script: &[IndexedOperation<LCSOp>]) -> Option<LCSMatch> {
     let mut longest = LCSMatch::empty();
 
-    let mut script_slice = &script[..];
+    let mut script_slice = script;
     while !script_slice.is_empty() {
         let op = &script_slice[0];
 

--- a/syntaxdot-summary/src/record_writer.rs
+++ b/syntaxdot-summary/src/record_writer.rs
@@ -3,6 +3,7 @@ use std::io::{self, Write};
 use crate::crc32::CheckSummer;
 
 /// Write data in TFRecord format.
+#[allow(clippy::upper_case_acronyms)]
 pub struct TFRecordWriter<W> {
     checksummer: CheckSummer,
     write: W,

--- a/syntaxdot-transformers/src/activations.rs
+++ b/syntaxdot-transformers/src/activations.rs
@@ -14,6 +14,7 @@ pub trait Activation: Clone + FallibleModule {}
 /// GELU(x)=x Φ(x)
 ///
 /// where Φ(x) is the CDF for the Gaussian distribution.
+#[allow(clippy::upper_case_acronyms)]
 #[derive(Clone, Copy, Debug)]
 pub struct GELUNew;
 
@@ -37,6 +38,7 @@ impl Activation for GELUNew {}
 /// GELU(x)=x Φ(x)
 ///
 /// where Φ(x) is the CDF for the Gaussian distribution.
+#[allow(clippy::upper_case_acronyms)]
 #[derive(Clone, Copy, Debug)]
 pub struct GELU;
 

--- a/syntaxdot/src/encoders/config.rs
+++ b/syntaxdot/src/encoders/config.rs
@@ -50,6 +50,7 @@ pub enum DependencyEncoder {
     RelativePosition,
 
     /// Encode a token's head by relative position of the POS tag.
+    #[allow(clippy::upper_case_acronyms)]
     RelativePOS(POSLayer),
 }
 

--- a/syntaxdot/src/encoders/encoders.rs
+++ b/syntaxdot/src/encoders/encoders.rs
@@ -92,6 +92,7 @@ pub enum DecoderError {
     #[error(transparent)]
     Layer(<LayerEncoder as SentenceDecoder>::Error),
 
+    #[allow(clippy::upper_case_acronyms)]
     #[error(transparent)]
     RelativePOS(<RelativePOSEncoder as SentenceDecoder>::Error),
 
@@ -111,6 +112,7 @@ pub enum EncoderError {
     #[error(transparent)]
     Layer(<LayerEncoder as SentenceEncoder>::Error),
 
+    #[allow(clippy::upper_case_acronyms)]
     #[error(transparent)]
     RelativePOS(<RelativePOSEncoder as SentenceEncoder>::Error),
 
@@ -126,6 +128,7 @@ pub enum EncoderError {
 pub enum Encoder {
     Lemma(CategoricalEncoderWrap<EditTreeEncoder, EditTree>),
     Layer(CategoricalEncoderWrap<LayerEncoder, String>),
+    #[allow(clippy::upper_case_acronyms)]
     RelativePOS(CategoricalEncoderWrap<RelativePOSEncoder, DependencyEncoding<RelativePOS>>),
     RelativePosition(
         CategoricalEncoderWrap<RelativePositionEncoder, DependencyEncoding<RelativePosition>>,

--- a/syntaxdot/src/error.rs
+++ b/syntaxdot/src/error.rs
@@ -15,6 +15,7 @@ pub enum SyntaxDotError {
     #[error(transparent)]
     BertError(#[from] TransformerError),
 
+    #[allow(clippy::upper_case_acronyms)]
     #[error(transparent)]
     ConlluIOError(#[from] conllu::IOError),
 
@@ -30,6 +31,7 @@ pub enum SyntaxDotError {
     #[error("Illegal configuration: {0}")]
     IllegalConfigurationError(String),
 
+    #[allow(clippy::upper_case_acronyms)]
     #[error(transparent)]
     IOError(#[from] io::Error),
 
@@ -49,6 +51,7 @@ pub enum SyntaxDotError {
     Tch(#[from] TchError),
 
     #[error(transparent)]
+    #[allow(clippy::upper_case_acronyms)]
     TOMLDeserializationError(#[from] toml::de::Error),
 
     #[error(transparent)]

--- a/syntaxdot/src/tagger/mod.rs
+++ b/syntaxdot/src/tagger/mod.rs
@@ -62,14 +62,17 @@ impl Tagger {
             predictions.biaffine_score_logits.is_some(),
         );
 
-        self.decode_sequence_labels(sentences, predictions.sequences_top_k)?;
-
+        // Decode dependencies before sequence labels. Biaffine parsing does not require any
+        // other annotations. Sequence labelers, however, may require dependencies (e.g. the
+        // TüBa-D/Z lemmatizer).
         if let (Some(encoder), Some(biaffine_score_logits)) = (
             self.biaffine_encoder.as_ref(),
             predictions.biaffine_score_logits,
         ) {
             tch::no_grad(|| self.decode_biaffine(encoder, sentences, biaffine_score_logits))?
         }
+
+        self.decode_sequence_labels(sentences, predictions.sequences_top_k)?;
 
         Ok(())
     }


### PR DESCRIPTION
Backport of #139 to the 0.3 release branch.