### PR TITLE
Add support for parallelizing annotation at the batch level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1249,6 +1249,7 @@ dependencies = [
  "log",
  "ndarray",
  "ordered-float",
+ "rayon",
  "serde_yaml",
  "stdinout",
  "syntaxdot",

--- a/syntaxdot-cli/Cargo.toml
+++ b/syntaxdot-cli/Cargo.toml
@@ -24,6 +24,7 @@ itertools = "0.10"
 log = "0.4"
 ndarray = "0.14"
 ordered-float = { version = "2", features = ["serde"] }
+rayon = "1"
 serde_yaml = "0.8"
 stdinout = "0.4"
 syntaxdot = { path = "../syntaxdot", version = "0.3.0", default-features = false }


### PR DESCRIPTION
SyntaxDot has so far used PyTorch inter/intraop parallelization. This
change adds support for parallelization at the batch level.  Batch-level
parallelization can be enabled with the `annotation-threads`
command-line option of `sticker annotate`.

For optimal performance, the `interop-threads` and `intraop-threads`
options should be set to 1.

Performance comparison on a Ryzen 3700X, Dutch medium UD model:

interop-threads = 4, intraop-threads = 4, annotation-threads = 1:

Processed 13028 sentences, 228 sents/s, 305073 pieces, 5333 pieces/s

interop-threads = 1, intraop-threads = 1, annotation-threads = 4:

Processed 13028 sentences, 247 sents/s, 305073 pieces, 5779 pieces/s
