### PR TITLE
CI: Pin the Rust version for clippy

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,6 +19,29 @@ jobs:
           command: fmt
           args: --all -- --check
 
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.51.0
+          override: true
+          components: clippy
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings
+
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -36,11 +59,6 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-          components: clippy
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
       - uses: actions-rs/cargo@v1
         with:
           command: test


### PR DESCRIPTION
We use the latest stable Rust in CI for rustfmt, clippy, and tests. This
has the downside that PRs are rejected when there is a new clippy
version with new lints that fire in unrelated parts of the project.

This change pins the clippy job to a particular Rust version. We
can then update clippy (and fix issues) separately from other PRs.
