### PR TITLE
Use 1 inter/intraop thread, 4 annotation threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 - Update to [libtorch
   1.9.0](https://github.com/pytorch/pytorch/releases/tag/v1.9.0) and
   [tch 0.5.0](https://github.com/LaurentMazare/tch-rs).
+- Change the default number of inter/intraop threads to 1. Use 4 threads for
+  annotation-level parallelization. This has shown to be faster for all models,
+  both on AMD Ryzen and Apple M1.
 
 ## 0.3.1
 

--- a/syntaxdot-cli/src/subcommands/annotate.rs
+++ b/syntaxdot-cli/src/subcommands/annotate.rs
@@ -111,21 +111,21 @@ impl SyntaxDotApp for AnnotateApp {
                     .help("Annotation threads")
                     .long("annotation-threads")
                     .value_name("N")
-                    .default_value("1"),
+                    .default_value("4"),
             )
             .arg(
                 Arg::with_name(NUM_INTEROP_THREADS)
                     .help("Inter op parallelism threads")
                     .long("interop-threads")
                     .value_name("N")
-                    .default_value("4"),
+                    .default_value("1"),
             )
             .arg(
                 Arg::with_name(NUM_INTRAOP_THREADS)
                     .help("Intra op parallelism threads")
                     .long("intraop-threads")
                     .value_name("N")
-                    .default_value("4"),
+                    .default_value("1"),
             )
             .arg(
                 Arg::with_name(MAX_LEN)


### PR DESCRIPTION
This is faster for all models, both on AMD Ryzen and Apple M1.
