### PR TITLE
Add the ReLU activation

### DIFF
--- a/syntaxdot-transformers/src/activations.rs
+++ b/syntaxdot-transformers/src/activations.rs
@@ -50,6 +50,22 @@ impl FallibleModule for Gelu {
 
 impl Activation for Gelu {}
 
+/// ReLU activation function
+///
+/// ReLU(x)=max(0,x)
+#[derive(Clone, Copy, Debug)]
+pub struct Relu;
+
+impl FallibleModule for Relu {
+    type Error = TransformerError;
+
+    fn forward(&self, input: &Tensor) -> Result<Tensor, Self::Error> {
+        Ok(input.f_relu()?)
+    }
+}
+
+impl Activation for Relu {}
+
 #[cfg(test)]
 mod tests {
     use std::convert::TryInto;

--- a/syntaxdot-transformers/src/models/bert/layer.rs
+++ b/syntaxdot-transformers/src/models/bert/layer.rs
@@ -342,6 +342,7 @@ pub(crate) fn bert_activations(
     match activation_name {
         "gelu" => Some(Box::new(activations::Gelu)),
         "gelu_new" => Some(Box::new(activations::GeluNew)),
+        "relu" => Some(Box::new(activations::Relu)),
         _ => None,
     }
 }


### PR DESCRIPTION
This is primarily useful in distillation, to distill into a model
that uses the ReLU activation for the position-wise feed-forward layers.
