### PR TITLE
Use dynamic batch sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,24 @@
 
 ### Changed
 
+- SyntaxDot now uses dynamic batch sizes. Before this change, the batch
+  size (`--batch-size`) was specified as the number of sentences per
+  batch. Since sentences are sorted by length before batching, annotation
+  is performed on batches with roughly equisized sequences. However,
+  later batches required more computations per batch due to longer
+  sequence lengths.
+
+  This change replaces the `--batch-size` option by the `--max-batch-pieces`
+  option. This option specifies the number of word/sentence pieces that
+  a batch should contain. SyntaxDot annotation creates batches that contains
+  at most that number of pieces. The only exception are single sentences
+  that are longer than the maximum number of batch pieces.
+
+  With this change, annotating each batch is approximately the same amount
+  of work. This leads to approximately 10% increase in performance.
+
+  Since the batch size is not fixed anymore, the readahead (`--readahead`)
+  is now specified in number of sentences.
 - Update to [libtorch
   1.9.0](https://github.com/pytorch/pytorch/releases/tag/v1.9.0) and
   [tch 0.5.0](https://github.com/LaurentMazare/tch-rs).

--- a/syntaxdot-cli/src/sent_proc.rs
+++ b/syntaxdot-cli/src/sent_proc.rs
@@ -1,9 +1,11 @@
+use std::iter::Peekable;
 use std::ops::Deref;
 
 use anyhow::Result;
 use conllu::io::WriteSentence;
-use rayon::iter::ParallelIterator;
+use rayon::iter::{ParallelBridge, ParallelIterator};
 use rayon::slice::ParallelSliceMut;
+use std::cmp;
 use syntaxdot::tagger::Tagger;
 use syntaxdot_tokenizers::SentenceWithPieces;
 
@@ -27,7 +29,7 @@ where
 {
     tagger: TaggerWrap<'a>,
     writer: W,
-    batch_size: usize,
+    max_batch_pieces: usize,
     max_len: Option<usize>,
     read_ahead: usize,
     buffer: Vec<SentenceWithPieces>,
@@ -41,34 +43,37 @@ where
     ///
     /// The sentence processor uses `tokenizer` and `tagger` to
     /// process a sentence. The annotated sentences are written to
-    /// `writer`. `batch_size` sentences are processed together,
-    /// ignoring sentences that are longer than `max_len`. The
-    /// processor reads ahead `read_ahead` batches before starting to
-    /// process sentences. This read-ahead is used to sort sentences
-    /// by length to speed up processing.
+    /// `writer`. The sentences are batched, so that batches contain at
+    /// most `max_batch_pieces` pieces. Sentences that are longer than
+    /// `max_len` are ignored. The processor reads ahead `read_ahead`
+    /// sentences before starting to process sentences. This read-ahead
+    /// is used to sort sentences by length to speed up processing.
     pub fn new(
         tagger: &'a Tagger,
         writer: W,
-        batch_size: usize,
+        max_batch_pieces: usize,
         max_len: Option<usize>,
         read_ahead: usize,
     ) -> Self {
-        assert!(batch_size > 0, "Batch size should at least be 1.");
+        assert!(
+            max_batch_pieces > 0,
+            "Maximum batch pieces should at least be 1."
+        );
         assert!(read_ahead > 0, "Read ahead should at least be 1.");
 
         SentProcessor {
             tagger: TaggerWrap(tagger),
             writer,
-            batch_size,
+            max_batch_pieces,
             max_len,
             read_ahead,
-            buffer: Vec::with_capacity(read_ahead * batch_size),
+            buffer: Vec::with_capacity(read_ahead),
         }
     }
 
     /// Process a sentence.
     ///
-    /// The sentences are not annotated until `batch_size * read_ahead` sentences
+    /// The sentences are not annotated until `read_ahead` sentences
     /// are queued using this method or the destructor is invoked. Once one of these
     /// two conditions are met, the sentences are annotated and written after
     /// annotation.
@@ -88,7 +93,7 @@ where
 
         self.buffer.push(tokenized_sentence);
 
-        if self.buffer.len() == self.batch_size * self.read_ahead {
+        if self.buffer.len() == self.read_ahead {
             self.tag_buffered_sentences()?;
         }
 
@@ -98,7 +103,7 @@ where
     fn tag_buffered_sentences(&mut self) -> Result<()> {
         // Sort sentences by length.
         let mut sent_refs: Vec<_> = self.buffer.iter_mut().collect();
-        sent_refs.sort_unstable_by_key(|s| s.pieces.len());
+        sent_refs.par_sort_unstable_by_key(|s| s.pieces.len());
 
         // Convince the type system that we are not borrowing SentProcessor, which is
         // not Sync.
@@ -106,11 +111,13 @@ where
 
         // Split in batches, tag, and merge results.
         sent_refs
-            .par_chunks_mut(self.batch_size)
-            .try_for_each(|batch| tagger.tag_sentences(batch))?;
+            .into_iter()
+            .max_pieces_batches(self.max_batch_pieces)
+            .par_bridge()
+            .try_for_each(|mut batch| tagger.tag_sentences(&mut batch))?;
 
         // Write out sentences.
-        let mut sents = Vec::with_capacity(self.read_ahead * self.batch_size);
+        let mut sents = Vec::with_capacity(self.read_ahead);
         std::mem::swap(&mut sents, &mut self.buffer);
         for sent in sents {
             self.writer.write_sentence(&sent.sentence)?;
@@ -130,5 +137,174 @@ where
                 log::error!("Error tagging sentences: {}", err);
             }
         }
+    }
+}
+
+trait MaxPieces<'a> {
+    fn max_pieces_batches(self, max_batch_pieces: usize) -> MaxPiecesIter<'a, Self>
+    where
+        Self: Sized + Iterator<Item = &'a mut SentenceWithPieces>;
+}
+
+impl<'a, I> MaxPieces<'a> for I
+where
+    I: Iterator<Item = &'a mut SentenceWithPieces>,
+{
+    fn max_pieces_batches(self, max_batch_pieces: usize) -> MaxPiecesIter<'a, Self> {
+        MaxPiecesIter {
+            inner: self.peekable(),
+            max_batch_pieces,
+        }
+    }
+}
+
+struct MaxPiecesIter<'a, I>
+where
+    I: Iterator<Item = &'a mut SentenceWithPieces>,
+{
+    inner: Peekable<I>,
+    max_batch_pieces: usize,
+}
+
+impl<'a, I> Iterator for MaxPiecesIter<'a, I>
+where
+    I: Iterator<Item = &'a mut SentenceWithPieces>,
+{
+    type Item = Vec<&'a mut SentenceWithPieces>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut batch = Vec::new();
+        let mut max_seq_len = 0;
+
+        loop {
+            match self.inner.peek() {
+                Some(next) => {
+                    // Compute how many pieces the batch would contain if the next sentence is added.
+                    let n_pieces = (batch.len() + 1) * cmp::max(max_seq_len, next.pieces.len());
+
+                    // If adding the next sentence would cross the threshold, return the batch as-is,
+                    // unless the batch is empty.
+                    if n_pieces > self.max_batch_pieces && !batch.is_empty() {
+                        return Some(batch);
+                    }
+                }
+                None => {
+                    // If there are no more sentences, return the current batch if it is empty,
+                    // or `None` otherwise to signal that the iterator is exhausted.
+                    if batch.is_empty() {
+                        return None;
+                    } else {
+                        return Some(batch);
+                    }
+                }
+            }
+
+            // Unwrapping is safe, since we already peeked above.
+            let next = self.inner.next().unwrap();
+
+            max_seq_len = cmp::max(max_seq_len, next.pieces.len());
+            batch.push(next);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ndarray::array;
+    use syntaxdot_tokenizers::SentenceWithPieces;
+
+    use crate::sent_proc::MaxPieces;
+
+    #[test]
+    fn max_pieces_iter_handles_empty() {
+        let mut sentences = vec![];
+        let mut iter = sentences.iter_mut().max_pieces_batches(4);
+        assert_eq!(iter.next(), None as Option<Vec<_>>);
+    }
+
+    #[test]
+    fn max_pieces_iter_handles_longer_than_max_batch_pieces() {
+        let mut sentences = vec![SentenceWithPieces {
+            pieces: array![0, 1, 2, 3, 4, 5],
+            sentence: Default::default(),
+            token_offsets: vec![],
+        }];
+
+        let mut iter = sentences.iter_mut().max_pieces_batches(4);
+
+        assert_eq!(
+            iter.next(),
+            Some(vec![&mut SentenceWithPieces {
+                pieces: array![0, 1, 2, 3, 4, 5],
+                sentence: Default::default(),
+                token_offsets: vec![]
+            },])
+        );
+
+        assert_eq!(iter.next(), None as Option<Vec<_>>);
+    }
+
+    #[test]
+    fn max_pieces_iter_splits_in_batches() {
+        let mut sentences = vec![
+            SentenceWithPieces {
+                pieces: array![0, 1],
+                sentence: Default::default(),
+                token_offsets: vec![],
+            },
+            SentenceWithPieces {
+                pieces: array![2, 3],
+                sentence: Default::default(),
+                token_offsets: vec![],
+            },
+            SentenceWithPieces {
+                pieces: array![4, 5, 6],
+                sentence: Default::default(),
+                token_offsets: vec![],
+            },
+            SentenceWithPieces {
+                pieces: array![7, 8],
+                sentence: Default::default(),
+                token_offsets: vec![],
+            },
+        ];
+
+        let mut iter = sentences.iter_mut().max_pieces_batches(4);
+
+        assert_eq!(
+            iter.next(),
+            Some(vec![
+                &mut SentenceWithPieces {
+                    pieces: array![0, 1],
+                    sentence: Default::default(),
+                    token_offsets: vec![]
+                },
+                &mut SentenceWithPieces {
+                    pieces: array![2, 3],
+                    sentence: Default::default(),
+                    token_offsets: vec![]
+                }
+            ])
+        );
+
+        assert_eq!(
+            iter.next(),
+            Some(vec![&mut SentenceWithPieces {
+                pieces: array![4, 5, 6],
+                sentence: Default::default(),
+                token_offsets: vec![]
+            }])
+        );
+
+        assert_eq!(
+            iter.next(),
+            Some(vec![&mut SentenceWithPieces {
+                pieces: array![7, 8],
+                sentence: Default::default(),
+                token_offsets: vec![]
+            }])
+        );
+
+        assert_eq!(iter.next(), None as Option<Vec<_>>);
     }
 }

--- a/syntaxdot-tokenizers/src/lib.rs
+++ b/syntaxdot-tokenizers/src/lib.rs
@@ -26,6 +26,7 @@ pub trait Tokenize: Send + Sync {
 }
 
 /// A sentence and its word pieces.
+#[derive(Debug, Eq, PartialEq)]
 pub struct SentenceWithPieces {
     /// Word pieces in a sentence.
     pub pieces: Array1<i64>,


### PR DESCRIPTION
Before this change, the batch size (`--batch-size`) was specified as the
number of sentences per batch. Since sentences are sorted by length
before batching, annotation is performed on batches with roughly
equisized sequences. However, later batches required more computations
per batch due to longer sequence lengths.

This change replaces the `--batch-size` option by the
`--max-batch-pieces` option. This option specifies the number of
word/sentence pieces that a batch should contain. SyntaxDot annotation
creates batches that contains at most that number of pieces. The only
exception are single sentences that are longer than the maximum number
of batch pieces.

With this change, annotating each batch is approximately the same amount
of work. This leads to approximately 10% increase in performance.

Since the batch size is not fixed anymore, the readahead (`--readahead`)
is now specified in number of sentences.
