### PR TITLE
Implement activation functions as an enum

### DIFF
--- a/syntaxdot-transformers/src/error.rs
+++ b/syntaxdot-transformers/src/error.rs
@@ -23,11 +23,3 @@ pub enum TransformerError {
     #[error("unknown activation function: {activation:?}")]
     UnknownActivationFunction { activation: String },
 }
-
-impl TransformerError {
-    pub(crate) fn unknown_activation_function(activation: impl Into<String>) -> Self {
-        TransformerError::UnknownActivationFunction {
-            activation: activation.into(),
-        }
-    }
-}

--- a/syntaxdot-transformers/src/models/albert/config.rs
+++ b/syntaxdot-transformers/src/models/albert/config.rs
@@ -1,15 +1,16 @@
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
+use crate::activations::Activation;
 use crate::models::bert::BertConfig;
 use crate::models::traits::WordEmbeddingsConfig;
 
 /// ALBERT model configuration.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize)]
 #[serde(default)]
 pub struct AlbertConfig {
     pub attention_probs_dropout_prob: f64,
     pub embedding_size: i64,
-    pub hidden_act: String,
+    pub hidden_act: Activation,
     pub hidden_dropout_prob: f64,
     pub hidden_size: i64,
     pub initializer_range: f64,
@@ -28,7 +29,7 @@ impl Default for AlbertConfig {
         AlbertConfig {
             attention_probs_dropout_prob: 0.,
             embedding_size: 128,
-            hidden_act: "gelu_new".to_owned(),
+            hidden_act: Activation::GeluNew,
             hidden_dropout_prob: 0.,
             hidden_size: 768,
             initializer_range: 0.02,
@@ -48,7 +49,7 @@ impl From<&AlbertConfig> for BertConfig {
     fn from(albert_config: &AlbertConfig) -> Self {
         BertConfig {
             attention_probs_dropout_prob: albert_config.attention_probs_dropout_prob,
-            hidden_act: albert_config.hidden_act.clone(),
+            hidden_act: albert_config.hidden_act,
             hidden_dropout_prob: albert_config.hidden_dropout_prob,
             hidden_size: albert_config.hidden_size,
             initializer_range: albert_config.initializer_range,

--- a/syntaxdot-transformers/src/models/albert/embeddings.rs
+++ b/syntaxdot-transformers/src/models/albert/embeddings.rs
@@ -99,13 +99,14 @@ mod tests {
     use tch::nn::VarStore;
     use tch::Device;
 
+    use crate::activations::Activation;
     use crate::models::albert::{AlbertConfig, AlbertEmbeddings};
 
     fn albert_config() -> AlbertConfig {
         AlbertConfig {
             attention_probs_dropout_prob: 0.,
             embedding_size: 128,
-            hidden_act: "gelu_new".to_string(),
+            hidden_act: Activation::GeluNew,
             hidden_dropout_prob: 0.,
             hidden_size: 768,
             initializer_range: 0.02,

--- a/syntaxdot-transformers/src/models/albert/encoder.rs
+++ b/syntaxdot-transformers/src/models/albert/encoder.rs
@@ -108,6 +108,7 @@ mod tests {
     use tch::{Device, Kind, Tensor};
 
     use super::AlbertEncoder;
+    use crate::activations::Activation;
     use crate::models::albert::{AlbertConfig, AlbertEmbeddings};
     use crate::models::Encoder;
     use crate::module::FallibleModuleT;
@@ -118,7 +119,7 @@ mod tests {
         AlbertConfig {
             attention_probs_dropout_prob: 0.,
             embedding_size: 128,
-            hidden_act: "gelu_new".to_string(),
+            hidden_act: Activation::GeluNew,
             hidden_dropout_prob: 0.,
             hidden_size: 768,
             initializer_range: 0.02,

--- a/syntaxdot-transformers/src/models/bert/config.rs
+++ b/syntaxdot-transformers/src/models/bert/config.rs
@@ -1,13 +1,14 @@
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
+use crate::activations::Activation;
 use crate::models::traits::WordEmbeddingsConfig;
 
 /// Bert model configuration.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize)]
 #[serde(default)]
 pub struct BertConfig {
     pub attention_probs_dropout_prob: f64,
-    pub hidden_act: String,
+    pub hidden_act: Activation,
     pub hidden_dropout_prob: f64,
     pub hidden_size: i64,
     pub initializer_range: f64,
@@ -24,7 +25,7 @@ impl Default for BertConfig {
     fn default() -> Self {
         BertConfig {
             attention_probs_dropout_prob: 0.1,
-            hidden_act: "gelu".to_owned(),
+            hidden_act: Activation::Gelu,
             hidden_dropout_prob: 0.1,
             hidden_size: 768,
             initializer_range: 0.02,

--- a/syntaxdot-transformers/src/models/bert/embeddings.rs
+++ b/syntaxdot-transformers/src/models/bert/embeddings.rs
@@ -153,6 +153,7 @@ mod tests {
     use tch::nn::VarStore;
     use tch::{Device, Kind, Tensor};
 
+    use crate::activations::Activation;
     use crate::models::bert::{BertConfig, BertEmbeddings};
     use crate::module::FallibleModuleT;
 
@@ -161,7 +162,7 @@ mod tests {
     fn german_bert_config() -> BertConfig {
         BertConfig {
             attention_probs_dropout_prob: 0.1,
-            hidden_act: "gelu".to_string(),
+            hidden_act: Activation::Gelu,
             hidden_dropout_prob: 0.1,
             hidden_size: 768,
             initializer_range: 0.02,

--- a/syntaxdot-transformers/src/models/bert/encoder.rs
+++ b/syntaxdot-transformers/src/models/bert/encoder.rs
@@ -90,6 +90,7 @@ mod tests {
     use tch::nn::VarStore;
     use tch::{Device, Kind, Tensor};
 
+    use crate::activations::Activation;
     use crate::models::bert::{BertConfig, BertEmbeddings, BertEncoder};
     use crate::models::Encoder;
     use crate::module::FallibleModuleT;
@@ -99,7 +100,7 @@ mod tests {
     fn german_bert_config() -> BertConfig {
         BertConfig {
             attention_probs_dropout_prob: 0.1,
-            hidden_act: "gelu".to_string(),
+            hidden_act: Activation::Gelu,
             hidden_dropout_prob: 0.1,
             hidden_size: 768,
             initializer_range: 0.02,

--- a/syntaxdot-transformers/src/models/bert/mod.rs
+++ b/syntaxdot-transformers/src/models/bert/mod.rs
@@ -10,5 +10,5 @@ mod encoder;
 pub use encoder::BertEncoder;
 
 mod layer;
+pub(crate) use layer::bert_linear;
 pub use layer::BertLayer;
-pub(crate) use layer::{bert_activations, bert_linear};

--- a/syntaxdot-transformers/src/models/roberta/mod.rs
+++ b/syntaxdot-transformers/src/models/roberta/mod.rs
@@ -90,6 +90,7 @@ mod tests {
     use tch::nn::VarStore;
     use tch::{Device, Kind, Tensor};
 
+    use crate::activations::Activation;
     use crate::models::bert::{BertConfig, BertEncoder};
     use crate::models::roberta::RobertaEmbeddings;
     use crate::models::Encoder;
@@ -100,7 +101,7 @@ mod tests {
     fn xlm_roberta_config() -> BertConfig {
         BertConfig {
             attention_probs_dropout_prob: 0.1,
-            hidden_act: "gelu".to_string(),
+            hidden_act: Activation::Gelu,
             hidden_dropout_prob: 0.1,
             hidden_size: 768,
             initializer_range: 0.02,

--- a/syntaxdot-transformers/src/models/sinusoidal/mod.rs
+++ b/syntaxdot-transformers/src/models/sinusoidal/mod.rs
@@ -101,6 +101,7 @@ mod tests {
     use tch::nn::VarStore;
     use tch::{Device, Kind, Tensor};
 
+    use crate::activations::Activation;
     use crate::models::bert::BertConfig;
     use crate::models::sinusoidal::SinusoidalEmbeddings;
     use crate::module::FallibleModuleT;
@@ -113,7 +114,7 @@ mod tests {
     fn german_bert_config() -> BertConfig {
         BertConfig {
             attention_probs_dropout_prob: 0.1,
-            hidden_act: "gelu".to_string(),
+            hidden_act: Activation::Gelu,
             hidden_dropout_prob: 0.1,
             hidden_size: 768,
             initializer_range: 0.02,

--- a/syntaxdot-transformers/src/models/squeeze_albert/mod.rs
+++ b/syntaxdot-transformers/src/models/squeeze_albert/mod.rs
@@ -13,11 +13,12 @@
 
 use std::borrow::Borrow;
 
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use syntaxdot_tch_ext::PathExt;
 use tch::nn::Module;
 use tch::Tensor;
 
+use crate::activations::Activation;
 use crate::error::TransformerError;
 use crate::models::albert::{AlbertConfig, AlbertEmbeddingProjection};
 use crate::models::bert::BertConfig;
@@ -38,12 +39,12 @@ use crate::util::LogitsMask;
 /// * ALBERT uses `num_hidden_groups` to configure the number of layer
 ///   groups and `embedding_size` to configure the size of piece
 ///   embeddings.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize)]
 #[serde(default)]
 pub struct SqueezeAlbertConfig {
     pub attention_probs_dropout_prob: f64,
     pub embedding_size: i64,
-    pub hidden_act: String,
+    pub hidden_act: Activation,
     pub hidden_dropout_prob: f64,
     pub hidden_size: i64,
     pub initializer_range: f64,
@@ -68,7 +69,7 @@ impl Default for SqueezeAlbertConfig {
         SqueezeAlbertConfig {
             attention_probs_dropout_prob: 0.,
             embedding_size: 128,
-            hidden_act: "gelu_new".to_owned(),
+            hidden_act: Activation::GeluNew,
             hidden_dropout_prob: 0.,
             hidden_size: 768,
             initializer_range: 0.02,
@@ -95,7 +96,7 @@ impl From<&SqueezeAlbertConfig> for AlbertConfig {
         AlbertConfig {
             attention_probs_dropout_prob: albert_config.attention_probs_dropout_prob,
             embedding_size: albert_config.embedding_size,
-            hidden_act: albert_config.hidden_act.clone(),
+            hidden_act: albert_config.hidden_act,
             hidden_dropout_prob: albert_config.hidden_dropout_prob,
             hidden_size: albert_config.hidden_size,
             initializer_range: albert_config.initializer_range,
@@ -115,7 +116,7 @@ impl From<&SqueezeAlbertConfig> for BertConfig {
     fn from(albert_config: &SqueezeAlbertConfig) -> Self {
         BertConfig {
             attention_probs_dropout_prob: albert_config.attention_probs_dropout_prob,
-            hidden_act: albert_config.hidden_act.clone(),
+            hidden_act: albert_config.hidden_act,
             hidden_dropout_prob: albert_config.hidden_dropout_prob,
             hidden_size: albert_config.hidden_size,
             initializer_range: albert_config.initializer_range,
@@ -135,7 +136,7 @@ impl From<&SqueezeAlbertConfig> for SqueezeBertConfig {
         SqueezeBertConfig {
             attention_probs_dropout_prob: config.attention_probs_dropout_prob,
             embedding_size: config.embedding_size,
-            hidden_act: config.hidden_act.clone(),
+            hidden_act: config.hidden_act,
             hidden_dropout_prob: config.hidden_dropout_prob,
             hidden_size: config.hidden_size,
             initializer_range: config.initializer_range,

--- a/syntaxdot-transformers/src/models/squeeze_bert/config.rs
+++ b/syntaxdot-transformers/src/models/squeeze_bert/config.rs
@@ -1,14 +1,15 @@
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
+use crate::activations::Activation;
 use crate::models::bert::BertConfig;
 
 /// SqueezeBert model configuration.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize)]
 #[serde(default)]
 pub struct SqueezeBertConfig {
     pub attention_probs_dropout_prob: f64,
     pub embedding_size: i64,
-    pub hidden_act: String,
+    pub hidden_act: Activation,
     pub hidden_dropout_prob: f64,
     pub hidden_size: i64,
     pub initializer_range: f64,
@@ -32,7 +33,7 @@ impl Default for SqueezeBertConfig {
         SqueezeBertConfig {
             attention_probs_dropout_prob: 0.1,
             embedding_size: 768,
-            hidden_act: "gelu".to_owned(),
+            hidden_act: Activation::Gelu,
             hidden_dropout_prob: 0.1,
             hidden_size: 768,
             initializer_range: 0.02,
@@ -57,7 +58,7 @@ impl From<&SqueezeBertConfig> for BertConfig {
     fn from(squeeze_bert_config: &SqueezeBertConfig) -> Self {
         BertConfig {
             attention_probs_dropout_prob: squeeze_bert_config.attention_probs_dropout_prob,
-            hidden_act: squeeze_bert_config.hidden_act.clone(),
+            hidden_act: squeeze_bert_config.hidden_act,
             hidden_dropout_prob: squeeze_bert_config.hidden_dropout_prob,
             hidden_size: squeeze_bert_config.hidden_size,
             initializer_range: squeeze_bert_config.initializer_range,

--- a/syntaxdot-transformers/src/models/squeeze_bert/embeddings.rs
+++ b/syntaxdot-transformers/src/models/squeeze_bert/embeddings.rs
@@ -9,6 +9,7 @@ mod tests {
     use tch::nn::VarStore;
     use tch::{Device, Kind, Tensor};
 
+    use crate::activations::Activation;
     use crate::models::bert::{BertConfig, BertEmbeddings};
     use crate::models::squeeze_bert::SqueezeBertConfig;
     use crate::module::FallibleModuleT;
@@ -19,7 +20,7 @@ mod tests {
         SqueezeBertConfig {
             attention_probs_dropout_prob: 0.1,
             embedding_size: 768,
-            hidden_act: "gelu".to_string(),
+            hidden_act: Activation::Gelu,
             hidden_dropout_prob: 0.1,
             hidden_size: 768,
             initializer_range: 0.02,

--- a/syntaxdot-transformers/src/models/squeeze_bert/encoder.rs
+++ b/syntaxdot-transformers/src/models/squeeze_bert/encoder.rs
@@ -100,6 +100,7 @@ mod tests {
     use tch::{Device, Kind, Tensor};
 
     use super::SqueezeBertEncoder;
+    use crate::activations::Activation;
     use crate::models::bert::{BertConfig, BertEmbeddings};
     use crate::models::squeeze_bert::SqueezeBertConfig;
     use crate::models::Encoder;
@@ -111,7 +112,7 @@ mod tests {
         SqueezeBertConfig {
             attention_probs_dropout_prob: 0.1,
             embedding_size: 768,
-            hidden_act: "gelu".to_string(),
+            hidden_act: Activation::Gelu,
             hidden_dropout_prob: 0.1,
             hidden_size: 768,
             initializer_range: 0.02,

--- a/syntaxdot/src/config.rs
+++ b/syntaxdot/src/config.rs
@@ -166,7 +166,7 @@ fn sinusoidal_normalize_default() -> bool {
     true
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize)]
 pub enum PretrainConfig {
     Albert(AlbertConfig),
     Bert(BertConfig),


### PR DESCRIPTION
Before this change, each activation function was a separate struct that
implemented the `Activation` trait. Despite this genericity, the
activation functions were not extendable outside the transformers crate,
since in order to parse the activation function string from the
pretrained model configuration, we need to know about all available
activation functions.

This change replaces the structs by a single `Activation` enum. This
simplifies some code across the crate.
