### PR TITLE
Fix the MST benchmark

### DIFF
--- a/syntaxdot-encoders/src/dependency/mod.rs
+++ b/syntaxdot-encoders/src/dependency/mod.rs
@@ -5,4 +5,5 @@ pub use encoder::{
     DependencyEncoding, EncodeError, ImmutableDependencyEncoder, MutableDependencyEncoder,
 };
 
-mod mst;
+#[doc(hidden)]
+pub mod mst;


### PR DESCRIPTION
The `mst` module was not visible. Make it public again, but hide the module
from documentation.
