### PR TITLE
Update to rand 0.8 in the syntaxdot crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,24 +398,13 @@ checksum = "7ab85b9b05e3978cc9a9cf8fea7f01b494e1a09ed3037e16ba39edc7a29eb61a"
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -623,7 +612,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65608f937acc725f5b164dcf40f4f0bc5d67dc268ab8a649d3002606718c4588"
 dependencies = [
  "ndarray",
- "rand 0.8.4",
+ "rand",
  "rand_distr",
 ]
 
@@ -837,37 +826,14 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc 0.2.0",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.3",
- "rand_hc 0.3.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
 ]
 
 [[package]]
@@ -877,16 +843,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.3",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
+ "rand_core",
 ]
 
 [[package]]
@@ -895,7 +852,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom 0.2.3",
+ "getrandom",
 ]
 
 [[package]]
@@ -905,16 +862,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "051b398806e42b9cd04ad9ec8f81e355d0a382c543ac6672c62f5a5b452ef142"
 dependencies = [
  "num-traits",
- "rand 0.8.4",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
+ "rand",
 ]
 
 [[package]]
@@ -923,16 +871,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
- "rand_core 0.6.3",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77d416b86801d23dde1aa643023b775c3a462efc0ed96443add11546cdf1dca8"
-dependencies = [
- "rand_core 0.5.1",
+ "rand_core",
 ]
 
 [[package]]
@@ -941,7 +880,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core 0.6.3",
+ "rand_core",
 ]
 
 [[package]]
@@ -1174,8 +1113,8 @@ dependencies = [
  "ndarray",
  "numberer",
  "ordered-float",
- "rand 0.7.3",
- "rand_xorshift 0.2.0",
+ "rand",
+ "rand_xorshift",
  "serde",
  "serde_json",
  "syntaxdot-encoders",
@@ -1231,8 +1170,8 @@ dependencies = [
  "ohnomore",
  "ordered-float",
  "petgraph",
- "rand 0.8.4",
- "rand_xorshift 0.3.0",
+ "rand",
+ "rand_xorshift",
  "seqalign",
  "serde",
  "serde_derive",
@@ -1290,7 +1229,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "ndarray",
- "rand 0.8.4",
+ "rand",
  "thiserror",
  "torch-sys",
  "zip",
@@ -1462,12 +1401,6 @@ dependencies = [
  "winapi",
  "winapi-util",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/syntaxdot/Cargo.toml
+++ b/syntaxdot/Cargo.toml
@@ -15,8 +15,8 @@ ndarray = "0.15"
 numberer = "0.2"
 log = "0.4"
 ordered-float = "2"
-rand = "0.7"
-rand_xorshift = "0.2"
+rand = "0.8"
+rand_xorshift = "0.3"
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
 syntaxdot-encoders = { path = "../syntaxdot-encoders", version = "0.4.0" }

--- a/syntaxdot/src/util.rs
+++ b/syntaxdot/src/util.rs
@@ -44,7 +44,7 @@ where
         } else {
             Some(
                 self.inner
-                    .swap_remove(self.rng.gen_range(0, self.inner.len())),
+                    .swap_remove(self.rng.gen_range(0..self.inner.len())),
             )
         }
     }
@@ -55,7 +55,7 @@ where
     pub fn push_and_remove_random(&mut self, replacement: T) -> T {
         self.inner.push(replacement);
         self.inner
-            .swap_remove(self.rng.gen_range(0, self.inner.len()))
+            .swap_remove(self.rng.gen_range(0..self.inner.len()))
     }
 }
 
@@ -75,27 +75,27 @@ mod tests {
         elems.push(3);
 
         // Before: [1 2 3]
-        assert_eq!(rng.gen_range(0, 4_usize), 1);
+        assert_eq!(rng.gen_range(0..4_usize), 1);
         assert_eq!(elems.push_and_remove_random(4), 2);
 
         // Before: [1 4 3]
-        assert_eq!(rng.gen_range(0, 4_usize), 2);
+        assert_eq!(rng.gen_range(0..4_usize), 2);
         assert_eq!(elems.push_and_remove_random(5), 3);
 
         // Before: [1 4 5]
-        assert_eq!(rng.gen_range(0, 4_usize), 1);
+        assert_eq!(rng.gen_range(0..4_usize), 1);
         assert_eq!(elems.push_and_remove_random(6), 4);
 
         // Before: [1 6 5]
-        assert_eq!(rng.gen_range(0, 3_usize), 1);
+        assert_eq!(rng.gen_range(0..3_usize), 1);
         assert_eq!(elems.remove_random().unwrap(), 6);
 
         // Before: [1 5]
-        assert_eq!(rng.gen_range(0, 2_usize), 0);
+        assert_eq!(rng.gen_range(0..2_usize), 0);
         assert_eq!(elems.remove_random().unwrap(), 1);
 
         // Before: [5]
-        assert_eq!(rng.gen_range(0, 1_usize), 0);
+        assert_eq!(rng.gen_range(0..1_usize), 0);
         assert_eq!(elems.remove_random().unwrap(), 5);
 
         // Exhausted


### PR DESCRIPTION
Avoids dependency on both rand 0.7 and 0.8.
