### PR TITLE
XlmRobertaTokenizer: replace sentencepiece unk id by fairseq's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
   1.10.0](https://github.com/pytorch/pytorch/releases/tag/v1.10.0) and
   [tch 0.6.1](https://github.com/LaurentMazare/tch-rs).
 
+### Fixed
+
+- Use the correct ID for unknown pieces in `XlmRobertaTokenizer`.
+
 ## 0.4.1
 
 ### Fixed

--- a/syntaxdot-tokenizers/src/xlm_roberta.rs
+++ b/syntaxdot-tokenizers/src/xlm_roberta.rs
@@ -9,6 +9,7 @@ use crate::TokenizerError;
 const FAIRSEQ_BOS_ID: i64 = 0;
 const FAIRSEQ_EOS_ID: i64 = 2;
 const FAIRSEQ_OFFSET: i64 = 1;
+const FAIRSEQ_UNK: i64 = 3;
 
 /// Tokenizer for Roberta models.
 ///
@@ -59,11 +60,14 @@ impl Tokenize for XlmRobertaTokenizer {
                 .expect("The sentencepiece tokenizer failed");
 
             if !token_pieces.is_empty() {
-                pieces.extend(
-                    token_pieces
-                        .into_iter()
-                        .map(|piece| piece.id as i64 + FAIRSEQ_OFFSET),
-                );
+                pieces.extend(token_pieces.into_iter().map(|piece| {
+                    let piece_id = piece.id as i64;
+                    if piece_id == self.spp.unknown_id() as i64 {
+                        FAIRSEQ_UNK
+                    } else {
+                        piece_id + FAIRSEQ_OFFSET
+                    }
+                }));
             } else {
                 // Use the unknown token id if sentencepiece does not
                 // give an output for the token. This should not


### PR DESCRIPTION
We were erroneously using sentencepiece's ID for unknown pieces (0), this ID corresponds to the `<s>` embedding in XLM-R. Fix this by replacing the ID by fairseq's ID for unknown pieces (3).

I don't see any difference when finetuning new Dutch models. It's possible that we never have unknown pieces for Dutch.

At any rate, this requires retraining of models for languages where the unknown piece is used.