### PR TITLE
Simplify relation prediction in the biaffine parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Changed
 
+- Change parser dependency relation prediction to use a biaffine layer rather
+  than a pairwise biaffine layer. This simplified some code and can be slightly
+  faster.
 - Update to [libtorch
   1.10.0](https://github.com/pytorch/pytorch/releases/tag/v1.10.0) and
   [tch 0.6.1](https://github.com/LaurentMazare/tch-rs).

--- a/syntaxdot/src/optimizers/grad_scale.rs
+++ b/syntaxdot/src/optimizers/grad_scale.rs
@@ -119,7 +119,7 @@ where
 {
     fn backward_step(&mut self, loss: &Tensor) -> Result<(), SyntaxDotError> {
         self.optimizer.trainable_variables().zero_grad();
-        self.scale(loss)?.backward();
+        self.scale(loss)?.f_backward()?;
         tch::no_grad(|| self.step());
         self.update();
         Ok(())


### PR DESCRIPTION
Before this change, we would use the following layers in the biaffine parser:

1. Pairwise biaffine layer for predicting heads. Output: `[batch_size, seq_len, seq_len]`

2. Pairwise biaffine layer for predicting dependency labels. Output: `[batch_size, seq_len, seq_len, n_rels]`

We would first MST-decode the output of (1) to find the heads. Then we would use the heads to gather the relevant relation predictions from (2). This change replaces (2) by:

2b. Biaffine layer for predicting dependencies. Output: `[batch_size, seq_len, n_rels]`

To make (2b) effective, we give it as the input the dependent representations of each tokens and the head representations gathered from the MST-decoded output of (1).

The new approach is mathematically equivalent to the old one, but is simpler and a bit faster.